### PR TITLE
[BUGFIX] Incorrect `ParameterTimer.ToString` Centiseconds

### DIFF
--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterTimer.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterTimer.cs
@@ -36,7 +36,8 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
             if (tS.Minutes > 0)
                 output += tS.Minutes.ToString("D2") + "'";
             output += tS.Seconds.ToString("D2") + "''";
-            output += "-" + tS.Milliseconds.ToString("D2").Substring(0, 2);
+            int centiseconds = tS.Milliseconds / 10;
+            output += "-" + centiseconds.ToString("D2");
             return output;
         }
     }


### PR DESCRIPTION
When dumping FNaF 2 events as text, in the `title` frame, the first event condition is a timer, which displays incorrectly as `00''-90` instead of `00''-09`. This occured because of doing a substring of the milliseconds instead of actually converting them to centiseconds.