### PR TITLE
Default to Windows build when platform information is unknown

### DIFF
--- a/Nebula.Core/Data/PackageReaders/CCNPackageData.cs
+++ b/Nebula.Core/Data/PackageReaders/CCNPackageData.cs
@@ -1,4 +1,4 @@
-﻿using Nebula.Core.Data.Chunks;
+using Nebula.Core.Data.Chunks;
 using Nebula.Core.Data.Chunks.FrameChunks;
 using Nebula.Core.Memory;
 using Nebula.Core.Utilities;
@@ -37,6 +37,8 @@ namespace Nebula.Core.Data.PackageReaders
                 NebulaCore._yunicode = true;
 
             Frames = new List<Frame>();
+            bool HasExtendedHeader = false;
+
             while (reader.HasMemory(8))
             {
                 var newChunk = Chunk.InitChunk(reader);
@@ -46,6 +48,17 @@ namespace Nebula.Core.Data.PackageReaders
                     NebulaCore.Seeded = true;
                 if (newChunk.ChunkID == 8787)
                     NebulaCore.Plus = true;
+                if (newChunk.ChunkID == 0x2245)
+                    HasExtendedHeader = true;
+
+                if (newChunk.ChunkID == 0x3333 && !HasExtendedHeader)
+                {
+                    // We've parsed all the chunks we could before the Frame chunk
+                    // but could not find the ExtendedHeader, so we have no platform info
+                    // Default to a Windows build.
+                    this.Log("No ExtendedHeader chunk found, defaulting to a Windows build.");
+                    NebulaCore.Windows = true;
+                }
 
                 ByteReader chunkReader = new ByteReader(newChunk.ChunkData!);
                 newChunk.ReadCCN(chunkReader);


### PR DESCRIPTION
This pull request adds a fallback for CCN game data that does not have an ExtendedHeader set (`CHUNK_APPHDR2`).

When ExtendedHeader is not set, no game platform information is set in `NebulaCore`. Which leads to NebulaCore.Windows being set to false by default, which leads to parameter group IDs being duplicated. When parameter group IDs are duplicated within a frame, Clickteam Fusion shows the "Corrupt objects/events" dialog box for each duplicate group ID instance... and crashes when you try to build the game. This happened to a 2009-era game.

My best guess is that ExtendedHeader was added sometime after Fusion 2 Build 256, after Flash support was added. I could not find any Fusion downloads for the older versions on Internet Archive. So I added the fallback logic to apply when there is no ExtendedHeader => hence no game platform information available, instead of locking it to a specific version.

===

I am disappointed and angered with your reaction to a possible contribution.

I have come to you - IN GOOD FAITH - to see if I could decompile (and recompile for a new platform) a game that I loved playing when I was younger. You said that you would need the original MFA to fix the problem - which I obviously did not have - and that you're the only one working on this and if you're *not smart enough*, it could not be done.

I spent HOURS debugging and bisecting the original game CCN and the MFA writing code to see what was going wrong!

I found the issue and let you know on Discord. With a CLEAR DESCRIPTION of what went wrong with the specific case. I did not plan to make a PR.

I was met by a Discord ban when I managed to pinpoint the issue and let you know!

Because I was apparently "planning on sending AI slop PRs"?!?!

Get REAL!

Would it have taken hours of research if I had an AI do it?
Would it have written such a cohesive case reproduction?

None of this pull request, none of the documentation, none of the hours spent debugging was done by an AI.

I am not part of the Clickteam community. I am a brand new person trying to do a brand new thing - I just happened to come here because the game I was looking at HAPPENED to be a Clickteam game.

And this is your reaction when somebody tries to contribute? Infuriating! And to think you're hoping for somebody to just APPEAR and fund your project with 10K! When you're throwing away help and connections like this???

Are you afraid that somebody smarter than you will pop up and do the work you've been doing before?
Are you afraid that somebody will replace your project?

Because I am not planning on doing any of those.

Looks like AI psychosis can affect people that are not using AI as well. I'm truly sorry.

Please review the PR and reconsider your actions.