### PR TITLE
Fixes for #22, #26, #35 and Large Files

### DIFF
--- a/Nebula.CLI/Program.cs
+++ b/Nebula.CLI/Program.cs
@@ -94,7 +94,7 @@ namespace Nebula
             AnsiConsole.Write(NebulaCore.ConsoleRule);
             AnsiConsole.Status().Spinner(Spinner.Known.Dots2).Start("Loading file", ctx =>
             {
-                fileReader = new ByteReader(File.ReadAllBytes(NebulaCore.FilePath));
+                fileReader = new ByteReader(NebulaCore.FilePath, FileMode.Open);
             });
 
             if (NebulaCore.CurrentReader == null)

--- a/Nebula.Core/Data/Chunks/BankChunks/Images/Image.cs
+++ b/Nebula.Core/Data/Chunks/BankChunks/Images/Image.cs
@@ -151,19 +151,6 @@ namespace Nebula.Core.Data.Chunks.BankChunks.Images
                                                         PixelFormat.Format32bppArgb);
 
                     byte[] colorArray = GetData();
-
-                    if (!IsMasked && colorArray != null)
-                    {
-                        ImageData = colorArray;
-                        if (!Parameters.GPUAcceleration)
-                            ImageData = ImageTranslatorCPU.RGBAToRGBMasked(this);
-                        else
-                            ImageData = ImageTranslatorGPU.RGBAToRGBMasked(this);
-
-                        GraphicMode = 4;
-                        IsMasked = true;
-                    }
-
                     Marshal.Copy(colorArray, 0, bmpData.Scan0, colorArray.Length);
                     BitmapCache.UnlockBits(bmpData);
                 }

--- a/Nebula.Core/Data/Chunks/BankChunks/Images/Image.cs
+++ b/Nebula.Core/Data/Chunks/BankChunks/Images/Image.cs
@@ -151,6 +151,19 @@ namespace Nebula.Core.Data.Chunks.BankChunks.Images
                                                         PixelFormat.Format32bppArgb);
 
                     byte[] colorArray = GetData();
+                    
+                    if (!IsMasked && colorArray != null)
+                    {
+                        ImageData = colorArray;
+                        if (!Parameters.GPUAcceleration)
+                            ImageData = ImageTranslatorCPU.RGBAToRGBMasked(this);
+                        else
+                            ImageData = ImageTranslatorGPU.RGBAToRGBMasked(this);
+
+                        GraphicMode = 4;
+                        IsMasked = true;
+                    }
+
                     Marshal.Copy(colorArray, 0, bmpData.Scan0, colorArray.Length);
                     BitmapCache.UnlockBits(bmpData);
                 }

--- a/Nebula.Core/Data/PackageReaders/CCNPackageData.cs
+++ b/Nebula.Core/Data/PackageReaders/CCNPackageData.cs
@@ -33,8 +33,10 @@ namespace Nebula.Core.Data.PackageReaders
                 this.Log("Fusion 1.5");
             }
 
-            if (Parameters.ForceUnicode || NebulaCore.Build >= 280)
+            if (Parameters.ForceUnicode)
                 NebulaCore._yunicode = true;
+            else if (!Parameters.IgnoreHeader)
+                NebulaCore._yunicode = Header != "PAME";
 
             Frames = new List<Frame>();
             bool HasExtendedHeader = false;

--- a/Nebula.Core/Data/PackageReaders/CCNPackageData.cs
+++ b/Nebula.Core/Data/PackageReaders/CCNPackageData.cs
@@ -33,7 +33,7 @@ namespace Nebula.Core.Data.PackageReaders
                 this.Log("Fusion 1.5");
             }
 
-            if (Parameters.ForceUnicode)
+            if (Parameters.ForceUnicode || NebulaCore.Build >= 280)
                 NebulaCore._yunicode = true;
 
             Frames = new List<Frame>();

--- a/Nebula.Core/FileReaders/EXEFileReader.cs
+++ b/Nebula.Core/FileReaders/EXEFileReader.cs
@@ -22,7 +22,11 @@ namespace Nebula.Core.FileReaders
 
         public void LoadGame(ByteReader fileReader, string filePath)
         {
+            // Close and reopen quickly so iconextractor can read the file without locking issues 
+            fileReader.Close();
             loadIcons(_filePath = filePath);
+            fileReader = new ByteReader(filePath, FileMode.Open);
+
             calculateEntryPoint(fileReader);
 
             if (!fileReader.HasMemory(1)) // Check for Unpacked

--- a/Nebula.Core/Utilities/ImageTranslatorCPU.cs
+++ b/Nebula.Core/Utilities/ImageTranslatorCPU.cs
@@ -54,6 +54,14 @@ namespace Nebula.Core.Utilities
             bool rleLoop = false;
             bool rleCommander = false;
             bool rle = img.Flags["RLE"] || img.Flags["RLEW"] || img.Flags["RLET"];
+            // initial command for RLE
+            if (command > 128){
+                command -= 128;
+                rleCommander = true;
+            }
+            else if (command == 0)
+                rleLoop = true;
+            
             if (rle)
                 position++;
 
@@ -140,9 +148,16 @@ namespace Nebula.Core.Utilities
             bool rleLoop = false;
             bool rleCommander = false;
             bool rle = img.Flags["RLE"] || img.Flags["RLEW"] || img.Flags["RLET"];
+            // initial command for RLE
+            if (command > 128){
+                command -= 128;
+                rleCommander = true;
+            }
+            else if (command == 0)
+                rleLoop = true;
+            
             if (rle)
                 position++;
-
             byte r = 0;
             byte g = 0;
             byte b = 0;
@@ -222,6 +237,14 @@ namespace Nebula.Core.Utilities
             bool rleLoop = false;
             bool rleCommander = false;
             bool rle = img.Flags["RLE"] || img.Flags["RLEW"] || img.Flags["RLET"];
+            // initial command for RLE
+            if (command > 128){
+                command -= 128;
+                rleCommander = true;
+            }
+            else if (command == 0)
+                rleLoop = true;
+            
             if (rle)
                 position++;
             byte r = 0;
@@ -621,6 +644,14 @@ namespace Nebula.Core.Utilities
             bool rleLoop = false;
             bool rleCommander = false;
             bool rle = img.Flags["RLE"] || img.Flags["RLEW"] || img.Flags["RLET"];
+            // initial command for RLE
+            if (command > 128){
+                command -= 128;
+                rleCommander = true;
+            }
+            else if (command == 0)
+                rleLoop = true;
+            
             if (rle)
                 position++;
 

--- a/Nebula.Core/Utilities/Parameters.cs
+++ b/Nebula.Core/Utilities/Parameters.cs
@@ -27,6 +27,8 @@ namespace Nebula.Core.Utilities
         public bool dump_all_chunks = false;
         public string comment_unicode = "Whether or not to force reading as unicode";
         public bool force_unicode = false;
+        public string comment_header = "Whether or not to avoid using the header for text encoding";
+        public bool ignore_header = false;
         public string comment_image_reader = "Whether or not to force reading images with the 2.5 reader rather than the 2.5+ reader";
         public bool force_image_reader = false;
         public string comment_gpu = "Whether or not to use the GPU to translate images (EXPERIMENTAL)";
@@ -60,6 +62,7 @@ namespace Nebula.Core.Utilities
         public static bool DumpUnknownChunks => Inst.dump_unk_chunks;
         public static bool DumpAllChunks => Inst.dump_all_chunks;
         public static bool ForceUnicode => Inst.force_unicode;
+        public static bool IgnoreHeader => Inst.ignore_header;
         public static bool GPUAcceleration => Inst.gpu_acceleration;
         public static bool ForceImageReader => Inst.force_image_reader;
         public static bool SilentLogEvents => Inst.silent_log_events;


### PR DESCRIPTION
Issues #22 and #26 seems to stem from the same thing. Adding the initial RLE command at start fixes it. 

As for the `GetBitmap()` change, removing the ImageData = x if statement, cause why when `PrepareForMfa()` does almost the same logic. Unless this was “faster” I don't see any change.

Issue #35 is the unicode being null. Simple fix is to set it to true if game build is greater than or equal to 280. since this was the supposed version unicode was added. _I haven't seen any other game using PAME while  >= 280._

If a clickteam exe is too large nebula would crash loading it. This is fixed by just using the file open mode. It conflicts with the icon extractor since file locking so the workaround is to just close the file stream and then reopen it. Since it's a stream anyway nothing is lost. the unpack check already does this anyway.