### PR TITLE
Experimental Android Support

### DIFF
--- a/Nebula.Core/Data/Chunks/BankChunks/Shaders/DX9ShaderBank.cs
+++ b/Nebula.Core/Data/Chunks/BankChunks/Shaders/DX9ShaderBank.cs
@@ -27,7 +27,7 @@ namespace Nebula.Core.Data.Chunks.BankChunks.Shaders
                 {
                     reader.Seek(Offsets[i]);
                     Shader shd = new Shader();
-                    if (NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && !NebulaCore.Android)
+                    if (NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && NebulaCore.Windows)
                         shd.ReadCCN(reader, i); // [296] i is needed for sending shader index to Shader.cs
                     else
                         shd.ReadCCN(reader);

--- a/Nebula.Core/Data/Chunks/BankChunks/Shaders/DX9ShaderBank.cs
+++ b/Nebula.Core/Data/Chunks/BankChunks/Shaders/DX9ShaderBank.cs
@@ -15,7 +15,6 @@ namespace Nebula.Core.Data.Chunks.BankChunks.Shaders
 
         public override void ReadCCN(ByteReader reader, params object[] extraInfo)
         {
-
             int Count = reader.ReadInt();
             Offsets = new int[Count];
             for (int i = 0; i < Count; i++)
@@ -28,7 +27,7 @@ namespace Nebula.Core.Data.Chunks.BankChunks.Shaders
                 {
                     reader.Seek(Offsets[i]);
                     Shader shd = new Shader();
-                    if (NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5)
+                    if (NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && !NebulaCore.Android)
                         shd.ReadCCN(reader, i); // [296] i is needed for sending shader index to Shader.cs
                     else
                         shd.ReadCCN(reader);
@@ -53,7 +52,6 @@ namespace Nebula.Core.Data.Chunks.BankChunks.Shaders
         {
 
         }
-
         public Shader this[int key]
         {
             get => Shaders[key];

--- a/Nebula.Core/Data/Chunks/BankChunks/Shaders/Shader.cs
+++ b/Nebula.Core/Data/Chunks/BankChunks/Shaders/Shader.cs
@@ -25,7 +25,7 @@ namespace Nebula.Core.Data.Chunks.BankChunks.Shaders
             int OptionsOffset = reader.ReadInt();
             int FXDataSize = reader.ReadInt();
 
-            if (NebulaCore.Build >= 296 && NebulaCore.Fusion == 2.5 && !NebulaCore.Android) // Android still contains real shader's name up to 296
+            if (NebulaCore.Build >= 296 && NebulaCore.Fusion == 2.5 && NebulaCore.Windows) // Android still contains real shader's name up to 296
             {
                 int shaderIndex = extraInfo.Length > 0 ? (int)extraInfo[0] : 0; // [296] Recieving index for naming it
                 Name = $"Shader_{shaderIndex}.fx"; // [296] Temporary name for implementation

--- a/Nebula.Core/Data/Chunks/BankChunks/Shaders/Shader.cs
+++ b/Nebula.Core/Data/Chunks/BankChunks/Shaders/Shader.cs
@@ -25,7 +25,7 @@ namespace Nebula.Core.Data.Chunks.BankChunks.Shaders
             int OptionsOffset = reader.ReadInt();
             int FXDataSize = reader.ReadInt();
 
-            if (NebulaCore.Build >= 296 && NebulaCore.Fusion == 2.5)
+            if (NebulaCore.Build >= 296 && NebulaCore.Fusion == 2.5 && !NebulaCore.Android) // Android still contains real shader's name up to 296
             {
                 int shaderIndex = extraInfo.Length > 0 ? (int)extraInfo[0] : 0; // [296] Recieving index for naming it
                 Name = $"Shader_{shaderIndex}.fx"; // [296] Temporary name for implementation

--- a/Nebula.Core/Data/Chunks/BankChunks/Shaders/ShaderBank.cs
+++ b/Nebula.Core/Data/Chunks/BankChunks/Shaders/ShaderBank.cs
@@ -1,5 +1,6 @@
 ﻿using Nebula.Core.Data.Chunks.BankChunks.Sounds;
 using Nebula.Core.Memory;
+using System.Runtime.CompilerServices;
 
 namespace Nebula.Core.Data.Chunks.BankChunks.Shaders
 {
@@ -17,7 +18,6 @@ namespace Nebula.Core.Data.Chunks.BankChunks.Shaders
 
         public override void ReadCCN(ByteReader reader, params object[] extraInfo)
         {
-			
             int Count = reader.ReadInt();
             Offsets = new int[Count];
             for (int i = 0; i < Count; i++)
@@ -30,7 +30,7 @@ namespace Nebula.Core.Data.Chunks.BankChunks.Shaders
                 {
                     reader.Seek(Offsets[i]);
                     Shader shd = new Shader();
-                    if (NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5)
+                    if (NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && !NebulaCore.Android)
                         shd.ReadCCN(reader, i); // [296] i is needed for sending shader index to Shader.cs
                     else
                         shd.ReadCCN(reader);

--- a/Nebula.Core/Data/Chunks/BankChunks/Shaders/ShaderBank.cs
+++ b/Nebula.Core/Data/Chunks/BankChunks/Shaders/ShaderBank.cs
@@ -30,7 +30,7 @@ namespace Nebula.Core.Data.Chunks.BankChunks.Shaders
                 {
                     reader.Seek(Offsets[i]);
                     Shader shd = new Shader();
-                    if (NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && !NebulaCore.Android)
+                    if (NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && NebulaCore.Windows)
                         shd.ReadCCN(reader, i); // [296] i is needed for sending shader index to Shader.cs
                     else
                         shd.ReadCCN(reader);

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterSample.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterSample.cs
@@ -21,7 +21,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
         {
             Handle = reader.ReadShort();
             SampleFlags.Value = reader.ReadUShort();
-            if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5)
+            if (NebulaCore.Build >= 296 && (NebulaCore.Windows || NebulaCore.Android) && NebulaCore.Fusion >= 2.5)
                 SoundBank.SampleParameters.Add(this);
             else
                 Name = reader.ReadYuniversal();

--- a/Nebula.Core/Data/Chunks/FrameChunks/FrameEffects.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/FrameEffects.cs
@@ -32,6 +32,12 @@ namespace Nebula.Core.Data.Chunks.FrameChunks
             ShaderHandle = reader.ReadInt();
             ShaderParameters = new ShaderParameter[reader.ReadInt()];
 
+            if (NebulaCore.Android && NebulaCore.Build < 296)
+            {
+                ShaderHandle = -1;
+                ShaderParameters = new ShaderParameter[0];
+            }
+
             if (ShaderParameters.Length > 0)
             {
                 Shader = NebulaCore.PackageData.ShaderBank[ShaderHandle];

--- a/Nebula.Core/Data/Chunks/FrameChunks/FrameLayerEffect.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/FrameLayerEffect.cs
@@ -33,7 +33,12 @@ namespace Nebula.Core.Data.Chunks.FrameChunks
             ShaderParameters = new ShaderParameter[reader.ReadInt()];
             int paramOffset = reader.ReadInt();
 
-            if (ShaderHandle >= 0)
+            if (NebulaCore.Android && NebulaCore.Build < 296)
+            {
+                ShaderHandle = -1;
+                ShaderParameters = new ShaderParameter[0];
+            }
+            else if (ShaderHandle >= 0)
                 Shader = NebulaCore.PackageData.ShaderBank[ShaderHandle];
 
             long returnOffset = reader.Tell();
@@ -41,16 +46,17 @@ namespace Nebula.Core.Data.Chunks.FrameChunks
             {
                 reader.Seek(startOffset + paramOffset);
                     for (int i = 0; i < ShaderParameters.Length; i++)
-                {
-                    ShaderParameters[i] = new ShaderParameter();
-                    ShaderParameters[i].Name = Shader.Parameters[i].Name;
-                    ShaderParameters[i].Type = Shader.Parameters[i].Type;
-                    if (ShaderParameters[i].Type == 1)
-                        ShaderParameters[i].FloatValue = reader.ReadFloat();
-                    else
-                        ShaderParameters[i].Value = reader.ReadInt();
-                }
-                Array.Resize(ref ShaderParameters, Shader.Parameters.Length);
+                        ShaderParameters[i] = new ShaderParameter();
+                    for (int i = 0; i < Shader.Parameters.Length; i++)
+                    {
+                        ShaderParameters[i].Name = Shader.Parameters[i].Name;
+                        ShaderParameters[i].Type = Shader.Parameters[i].Type;
+                        if (ShaderParameters[i].Type == 1)
+                            ShaderParameters[i].FloatValue = reader.ReadFloat();
+                        else
+                            ShaderParameters[i].Value = reader.ReadInt();
+                    }
+                    Array.Resize(ref ShaderParameters, Shader.Parameters.Length);
             }
             reader.Seek(returnOffset);
         }

--- a/Nebula.Core/FileReaders/APKFileReader.cs
+++ b/Nebula.Core/FileReaders/APKFileReader.cs
@@ -44,23 +44,31 @@ namespace Nebula.Core.FileReaders
                         // TODO
                     }
                 }
-                else if ((Directory.GetParent(entry.FullName)?.Name == "mipmap-hdpi-v4" ||
-                         Directory.GetParent(entry.FullName)?.Name == "mipmap-mdpi-v4" ||
-                         Directory.GetParent(entry.FullName)?.Name == "mipmap-xhdpi-v4" ||
-                         Directory.GetParent(entry.FullName)?.Name == "mipmap-xxhdpi-v4" ||
-                         Directory.GetParent(entry.FullName)?.Name == "mipmap-xxxhdpi-v4") &&
-                         entry.Name == "ic_launcher.png")
+                else if (NebulaCore.Build >= 296)
                 {
-                    loadIcons(new Bitmap(Bitmap.FromStream(entry.Open())));
+                        if ((Directory.GetParent(entry.FullName)?.Name == "mipmap-xxhdpi-v4" ||
+                            Directory.GetParent(entry.FullName)?.Name == "mipmap-xxxhdpi-v4") &&
+                            entry.Name == "ic_launcher.png") // only for 296
+                        {
+                        loadIcons(new Bitmap(Bitmap.FromStream(entry.Open())));
+                        }
                 }
+                else
+                {
+                    if ((Directory.GetParent(entry.FullName)?.Name == "drawable-xhdpi" ||
+                        Directory.GetParent(entry.FullName)?.Name == "drawable-xxhdpi-v4" ||
+                         Directory.GetParent(entry.FullName)?.Name == "drawable-xxxhdpi-v4") && 
+                         entry.Name == "launcher.png") // loading icons from 282 version and above
+                    {
+                        loadIcons(new Bitmap(Bitmap.FromStream(entry.Open())));
+                    }
+
+                }
+                
             }
 
             if (ccnReader != null)
-            {
-                NebulaCore.Android = true;
                 Package.Read(ccnReader);
-            }
-                
         }
 
         private void loadIcons(Bitmap bmp)

--- a/Nebula.Core/FileReaders/APKFileReader.cs
+++ b/Nebula.Core/FileReaders/APKFileReader.cs
@@ -23,10 +23,12 @@ namespace Nebula.Core.FileReaders
         public void LoadGame(ByteReader fileReader, string filePath)
         {
             ByteReader? ccnReader = null;
-            ZipArchive archive = ZipFile.OpenRead(_filePath = filePath);
+
+            FileStream fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            ZipArchive archive = new ZipArchive(fs, ZipArchiveMode.Read);
             foreach (ZipArchiveEntry entry in archive.Entries)
             {
-                if (Directory.GetParent(entry.FullName)?.Name == "raw")
+                if (Directory.GetParent(entry.Name)?.Name == "assets" || Directory.GetParent(entry.FullName)?.Name == "raw")
                 {
                     if (Path.GetExtension(entry.Name) == ".ccn")
                     {
@@ -42,21 +44,30 @@ namespace Nebula.Core.FileReaders
                         // TODO
                     }
                 }
-                else if ((Directory.GetParent(entry.FullName)?.Name == "drawable-xhdpi" ||
-                         Directory.GetParent(entry.FullName)?.Name == "drawable-xxxhdpi-v4") &&
-                         entry.Name == "launcher.png")
+                else if ((Directory.GetParent(entry.FullName)?.Name == "mipmap-hdpi-v4" ||
+                         Directory.GetParent(entry.FullName)?.Name == "mipmap-mdpi-v4" ||
+                         Directory.GetParent(entry.FullName)?.Name == "mipmap-xhdpi-v4" ||
+                         Directory.GetParent(entry.FullName)?.Name == "mipmap-xxhdpi-v4" ||
+                         Directory.GetParent(entry.FullName)?.Name == "mipmap-xxxhdpi-v4") &&
+                         entry.Name == "ic_launcher.png")
                 {
                     loadIcons(new Bitmap(Bitmap.FromStream(entry.Open())));
                 }
             }
-            archive.Dispose();
 
             if (ccnReader != null)
+            {
+                NebulaCore.Android = true;
                 Package.Read(ccnReader);
+            }
+                
         }
 
         private void loadIcons(Bitmap bmp)
         {
+            if (_icons.Count > 0) 
+                return;
+
             _icons.Add(16,  bmp.ResizeImage(new Size(16, 16)));
             _icons.Add(32,  bmp.ResizeImage(new Size(32, 32)));
             _icons.Add(64,  bmp.ResizeImage(new Size(48, 48)));

--- a/Nebula.Tools/GameDumper/AssetDumpers/ShaderDumper.cs
+++ b/Nebula.Tools/GameDumper/AssetDumpers/ShaderDumper.cs
@@ -27,10 +27,10 @@ namespace GameDumper.AssetDumpers
             for (int i = 0; i < shdrs.Length; i++)
             {
                 string filePath = "";
-                if (!NebulaCore.Android)
-                    filePath = path + Path.GetFileNameWithoutExtension(shdrs[i].Name) + (shdrs[i].Compiled ? ".fxc" : ".fx");
+                if (NebulaCore.Android)
+		    filePath = path + Path.GetFileNameWithoutExtension(shdrs[i].Name) + ".fxao"; // Android has only OpenGL shader, there's no DX9 and DX11 (so you need to find them somewhere else)
                 else
-                    filePath = path + Path.GetFileNameWithoutExtension(shdrs[i].Name) + ".fxao"; // Android has only OpenGL shader, there's no DX9 and DX11 (so you need to find them somewhere else)
+                    filePath = path + Path.GetFileNameWithoutExtension(shdrs[i].Name) + (shdrs[i].Compiled ? ".fxc" : ".fx");
                 File.WriteAllBytes(filePath, shdrs[i].FXData);
                 filePath = path + Path.GetFileNameWithoutExtension(shdrs[i].Name) + ".xml";
 

--- a/Nebula.Tools/GameDumper/AssetDumpers/ShaderDumper.cs
+++ b/Nebula.Tools/GameDumper/AssetDumpers/ShaderDumper.cs
@@ -26,7 +26,11 @@ namespace GameDumper.AssetDumpers
             int[] keys = shdBnk.Shaders.Keys.ToArray();
             for (int i = 0; i < shdrs.Length; i++)
             {
-                string filePath = path + Path.GetFileNameWithoutExtension(shdrs[i].Name) + (shdrs[i].Compiled ? ".fxc" : ".fx");
+                string filePath = "";
+                if (!NebulaCore.Android)
+                    filePath = path + Path.GetFileNameWithoutExtension(shdrs[i].Name) + (shdrs[i].Compiled ? ".fxc" : ".fx");
+                else
+                    filePath = path + Path.GetFileNameWithoutExtension(shdrs[i].Name) + ".fxao"; // Android has only OpenGL shader, there's no DX9 and DX11 (so you need to find them somewhere else)
                 File.WriteAllBytes(filePath, shdrs[i].FXData);
                 filePath = path + Path.GetFileNameWithoutExtension(shdrs[i].Name) + ".xml";
 


### PR DESCRIPTION
What was done:
- Added experimental Android support (not fully finished): can be parsed to MFA, mostly will be functional, but actions and conditions with float numbers in it won't work (not all games can be parsed)
- Changed path for adding icon to the project for Android
- For Android, you can dump OpenGL ES shaders (.fxao), but any game below than 296 won't add any shaders in the project (until figuring out how to fix this). Since Android contains only OpenGL shaders in some shader bank (there's also no DX11 shaders), you need to find in the internet its original shader
- Also fixed APK reading (there was an error with "APK being used by other proccess" while tried to read any APK file)