### PR TITLE
Android support's update

### DIFF
--- a/Nebula.Core/Data/Chunks/BankChunks/Fonts/Font.cs
+++ b/Nebula.Core/Data/Chunks/BankChunks/Fonts/Font.cs
@@ -83,7 +83,10 @@ namespace Nebula.Core.Data.Chunks.BankChunks.Fonts
             ClipPrecision = dataReader.ReadByte();
             Quality = dataReader.ReadByte();
             PitchAndFamily = dataReader.ReadByte();
-            Name = dataReader.ReadYuniversal();
+            if (NebulaCore.Android)
+                Name = dataReader.ReadYuniversal(32); // fixed length for Android font names
+            else
+                Name = dataReader.ReadYuniversal();
         }
 
         public override void ReadMFA(ByteReader reader, params object[] extraInfo)

--- a/Nebula.Core/Data/Chunks/BankChunks/Sounds/Sound.cs
+++ b/Nebula.Core/Data/Chunks/BankChunks/Sounds/Sound.cs
@@ -12,7 +12,7 @@ namespace Nebula.Core.Data.Chunks.BankChunks.Sounds
             "Check",                        // Will not compile exes if off
             "", "", "", "LoadOnCall",       // Load on Call
             "PlayFromDisk",                 // Play from Disk
-            "", "", "HasName",              // Has Name (Android Only?)
+            "", "", "HasName",              // Has Name (At least it's for Android, or else it will give dictionary key not found)
             "", "", "", "", "", "NameCrop"  // Name Crop
         );
         public int Frequency;
@@ -41,8 +41,6 @@ namespace Nebula.Core.Data.Chunks.BankChunks.Sounds
                 else
                     Name = "S" + Handle.ToString("D4");
 
-                // Temp until reading from the apk is added
-                Flags["PlayFromDisk"] = false;
                 return;
             }
             else if (NebulaCore.iOS)

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/Expressions/ExpressionDouble.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/Expressions/ExpressionDouble.cs
@@ -1,4 +1,5 @@
 ﻿using Nebula.Core.Memory;
+using Nebula.Core.Utilities;
 
 namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
 {
@@ -6,6 +7,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
     {
         public double Value;
         public float Value2;
+        public double Value3;
 
         public ExpressionDouble()
         {
@@ -14,8 +16,17 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
 
         public override void ReadCCN(ByteReader reader, params object[] extraInfo)
         {
-            Value = reader.ReadDouble();
-            Value2 = reader.ReadFloat();
+            if (NebulaCore.Windows)
+            {
+                Value = reader.ReadDouble();
+                Value2 = reader.ReadFloat();
+            }
+            else
+            {
+                reader.Skip(8); // skipping 8 bytes for getting real value
+                Value2 = reader.ReadFloat(); // fully reads float expression
+                Value = Math.Round((double)Value2, 5); // rounding the value for preventing a lot of floating-point numbers
+            }
         }
 
         public override void WriteMFA(ByteWriter writer, params object[] extraInfo)

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/Expressions/ExpressionDouble.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/Expressions/ExpressionDouble.cs
@@ -7,7 +7,6 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
     {
         public double Value;
         public float Value2;
-        public double Value3;
 
         public ExpressionDouble()
         {

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterSample.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterSample.cs
@@ -21,7 +21,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
         {
             Handle = reader.ReadShort();
             SampleFlags.Value = reader.ReadUShort();
-            if (NebulaCore.Build >= 296 && (NebulaCore.Windows || NebulaCore.Android) && NebulaCore.Fusion >= 2.5)
+            if (NebulaCore.Build >= 296 && (NebulaCore.Windows || NebulaCore.Android) && NebulaCore.Fusion >= 2.5 || NebulaCore.Android && NebulaCore.Build <= 290)
                 SoundBank.SampleParameters.Add(this);
             else
                 Name = reader.ReadYuniversal();

--- a/Nebula.Core/Data/Chunks/FrameChunks/FrameEffects.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/FrameEffects.cs
@@ -1,5 +1,6 @@
 ﻿using Nebula.Core.Data.Chunks.BankChunks.Shaders;
 using Nebula.Core.Memory;
+using Nebula.Core.Utilities;
 using System.Drawing;
 
 namespace Nebula.Core.Data.Chunks.FrameChunks
@@ -32,15 +33,26 @@ namespace Nebula.Core.Data.Chunks.FrameChunks
             ShaderHandle = reader.ReadInt();
             ShaderParameters = new ShaderParameter[reader.ReadInt()];
 
-            if (NebulaCore.Android && NebulaCore.Build < 296)
+            if (ShaderHandle >= 0)
             {
-                ShaderHandle = -1;
-                ShaderParameters = new ShaderParameter[0];
+                if (NebulaCore.Windows)
+                    Shader = NebulaCore.PackageData.ShaderBank[ShaderHandle];
+                else
+                {
+                    if (NebulaCore.PackageData.ShaderBank.ContainsKey(ShaderHandle))
+                    {
+                        Shader = NebulaCore.PackageData.ShaderBank[ShaderHandle];
+                    }
+                    else
+                    {
+                        ShaderHandle = -1;
+                        ShaderParameters = new ShaderParameter[0];
+                    }
+                }
             }
 
             if (ShaderParameters.Length > 0)
             {
-                Shader = NebulaCore.PackageData.ShaderBank[ShaderHandle];
                 for (int i = 0; i < ShaderParameters.Length; i++)
                     ShaderParameters[i] = new ShaderParameter();
                 for (int i = 0; i < Shader.Parameters.Length; i++)

--- a/Nebula.Core/Data/Chunks/FrameChunks/FrameLayerEffect.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/FrameLayerEffect.cs
@@ -1,5 +1,6 @@
 ﻿using Nebula.Core.Data.Chunks.BankChunks.Shaders;
 using Nebula.Core.Memory;
+using Nebula.Core.Utilities;
 using System.Drawing;
 
 namespace Nebula.Core.Data.Chunks.FrameChunks
@@ -33,30 +34,41 @@ namespace Nebula.Core.Data.Chunks.FrameChunks
             ShaderParameters = new ShaderParameter[reader.ReadInt()];
             int paramOffset = reader.ReadInt();
 
-            if (NebulaCore.Android && NebulaCore.Build < 296)
+            if (ShaderHandle >= 0)
             {
-                ShaderHandle = -1;
-                ShaderParameters = new ShaderParameter[0];
+                if (NebulaCore.Windows)
+                    Shader = NebulaCore.PackageData.ShaderBank[ShaderHandle];
+                else
+                {
+                    if (NebulaCore.PackageData.ShaderBank.ContainsKey(ShaderHandle))
+                    {
+                        Shader = NebulaCore.PackageData.ShaderBank[ShaderHandle];
+                    }
+                    else
+                    {
+                        ShaderHandle = -1;
+                        ShaderParameters = new ShaderParameter[0];
+                    }
+                } 
             }
-            else if (ShaderHandle >= 0)
-                Shader = NebulaCore.PackageData.ShaderBank[ShaderHandle];
-
+                
+            
             long returnOffset = reader.Tell();
             if (paramOffset != 0)
             {
                 reader.Seek(startOffset + paramOffset);
-                    for (int i = 0; i < ShaderParameters.Length; i++)
-                        ShaderParameters[i] = new ShaderParameter();
-                    for (int i = 0; i < Shader.Parameters.Length; i++)
-                    {
-                        ShaderParameters[i].Name = Shader.Parameters[i].Name;
-                        ShaderParameters[i].Type = Shader.Parameters[i].Type;
-                        if (ShaderParameters[i].Type == 1)
-                            ShaderParameters[i].FloatValue = reader.ReadFloat();
-                        else
-                            ShaderParameters[i].Value = reader.ReadInt();
-                    }
-                    Array.Resize(ref ShaderParameters, Shader.Parameters.Length);
+                for (int i = 0; i < ShaderParameters.Length; i++)
+                    ShaderParameters[i] = new ShaderParameter();
+                for (int i = 0; i < Shader.Parameters.Length; i++)
+                {
+                    ShaderParameters[i].Name = Shader.Parameters[i].Name;
+                    ShaderParameters[i].Type = Shader.Parameters[i].Type;
+                    if (ShaderParameters[i].Type == 1)
+                        ShaderParameters[i].FloatValue = reader.ReadFloat();
+                    else
+                        ShaderParameters[i].Value = reader.ReadInt();
+                }
+                Array.Resize(ref ShaderParameters, Shader.Parameters.Length);
             }
             reader.Seek(returnOffset);
         }

--- a/Nebula.Core/FileReaders/APKFileReader.cs
+++ b/Nebula.Core/FileReaders/APKFileReader.cs
@@ -1,11 +1,8 @@
 ﻿using Nebula.Core.Data;
-using Nebula.Core.Data.Chunks.BankChunks.Fonts;
-using Nebula.Core.Data.Chunks.BankChunks.Sounds;
 using Nebula.Core.Data.Chunks.BankChunks.TrueTypeFonts;
 using Nebula.Core.Data.PackageReaders;
 using Nebula.Core.Memory;
 using Nebula.Core.Utilities;
-using System.ComponentModel.Design;
 using System.Drawing;
 using System.IO.Compression;
 
@@ -101,7 +98,7 @@ namespace Nebula.Core.FileReaders
             foreach (var soundFile in soundFiles)
             {
                 // getting file's name without extension
-                string fileName = Path.GetFileNameWithoutExtension(soundFile.Key);
+                string fileName = Path.GetFileNameWithoutExtension(soundFile.Key).ToLower();
                 // since Android sound names are s0001, s0002 and etc, we'll try to find its real name in sound bank from its handle in file's name
                 if (fileName.StartsWith('s') && fileName.Length >= 5 && uint.TryParse(fileName.Substring(1), out uint fileHandle))
                 {

--- a/Nebula.Core/FileReaders/APKFileReader.cs
+++ b/Nebula.Core/FileReaders/APKFileReader.cs
@@ -1,7 +1,11 @@
 ﻿using Nebula.Core.Data;
+using Nebula.Core.Data.Chunks.BankChunks.Fonts;
+using Nebula.Core.Data.Chunks.BankChunks.Sounds;
+using Nebula.Core.Data.Chunks.BankChunks.TrueTypeFonts;
 using Nebula.Core.Data.PackageReaders;
 using Nebula.Core.Memory;
 using Nebula.Core.Utilities;
+using System.ComponentModel.Design;
 using System.Drawing;
 using System.IO.Compression;
 
@@ -12,6 +16,8 @@ namespace Nebula.Core.FileReaders
         public string Name => "APK";
         public Dictionary<int, Bitmap> Icons { get { return _icons; } set { _icons = value; } }
         private Dictionary<int, Bitmap> _icons = new Dictionary<int, Bitmap>();
+
+        Dictionary<string, byte[]> soundFiles = new(); // dictionary for saving each founded sound
 
         public string FilePath { get { return _filePath; } set { _filePath = value; } }
         public string _filePath = string.Empty;
@@ -28,7 +34,7 @@ namespace Nebula.Core.FileReaders
             ZipArchive archive = new ZipArchive(fs, ZipArchiveMode.Read);
             foreach (ZipArchiveEntry entry in archive.Entries)
             {
-                if (Directory.GetParent(entry.Name)?.Name == "assets" || Directory.GetParent(entry.FullName)?.Name == "raw")
+                if (Directory.GetParent(entry.FullName)?.Name == "assets" || Directory.GetParent(entry.FullName)?.Name == "raw")
                 {
                     if (Path.GetExtension(entry.Name) == ".ccn")
                     {
@@ -41,34 +47,73 @@ namespace Nebula.Core.FileReaders
                              Path.GetExtension(entry.Name) == ".ogg" ||
                              Path.GetExtension(entry.Name) == ".wav")
                     {
-                        // TODO
+                        using MemoryStream ms = new();
+                        entry.Open().CopyTo(ms);
+                        soundFiles[entry.Name] = ms.ToArray(); // saving it to dictionary
                     }
                 }
-                else if (NebulaCore.Build >= 296)
+                if (Directory.GetParent(entry.FullName)?.Name == "fonts" && Path.GetExtension(entry.Name) == ".ttf")
                 {
-                        if ((Directory.GetParent(entry.FullName)?.Name == "mipmap-xxhdpi-v4" ||
-                            Directory.GetParent(entry.FullName)?.Name == "mipmap-xxxhdpi-v4") &&
-                            entry.Name == "ic_launcher.png") // only for 296
-                        {
-                        loadIcons(new Bitmap(Bitmap.FromStream(entry.Open())));
-                        }
+                    loadFonts(entry); 
                 }
-                else
-                {
-                    if ((Directory.GetParent(entry.FullName)?.Name == "drawable-xhdpi" ||
-                        Directory.GetParent(entry.FullName)?.Name == "drawable-xxhdpi-v4" ||
-                         Directory.GetParent(entry.FullName)?.Name == "drawable-xxxhdpi-v4") && 
-                         entry.Name == "launcher.png") // loading icons from 282 version and above
-                    {
-                        loadIcons(new Bitmap(Bitmap.FromStream(entry.Open())));
-                    }
 
+                if ((Directory.GetParent(entry.FullName)?.Name == "mipmap-xxhdpi-v4" || Directory.GetParent(entry.FullName)?.Name == "mipmap-xxxhdpi-v4") &&
+                    entry.Name == "ic_launcher.png") // for newer versions
+                {
+                    loadIcons(new Bitmap(Bitmap.FromStream(entry.Open())));
                 }
-                
+                else if ((Directory.GetParent(entry.FullName)?.Name == "drawable-xhdpi" || Directory.GetParent(entry.FullName)?.Name == "drawable-xxhdpi-v4" ||
+                    Directory.GetParent(entry.FullName)?.Name == "drawable-xxxhdpi-v4") && entry.Name == "launcher.png") // for older versions
+                {
+                    loadIcons(new Bitmap(Bitmap.FromStream(entry.Open())));
+                }
             }
 
             if (ccnReader != null)
+            {
+                NebulaCore.Android = true; // flag is needed for fixing some issues
                 Package.Read(ccnReader);
+                LoadAndroidSounds(soundFiles); // put here for fixing issues with sound dumping
+            }
+        }
+
+        private void loadFonts(ZipArchiveEntry entry)
+        {
+            using var stream = entry.Open(); // getting path for retrieving fonts
+            using var memoryStream = new MemoryStream();
+            stream.CopyTo(memoryStream);
+            string fontName = Path.GetFileNameWithoutExtension(entry.Name); // found one - getting its name
+            byte[] fontData = memoryStream.ToArray(); // getting its data
+            TrueTypeFont ttf = new TrueTypeFont
+            {
+                Name = fontName,
+                FontData = fontData
+            };
+            NebulaCore.PackageData.TrueTypeFontBank.Fonts.Add(ttf); // then add font to the bank
+        }
+
+        private void LoadAndroidSounds(Dictionary<string, byte[]> soundFiles)
+        {
+            // no sounds - skip
+            if (soundFiles.Count == 0 || NebulaCore.PackageData.SoundBank.Sounds.Count == 0)
+                return;
+
+            foreach (var soundFile in soundFiles)
+            {
+                // getting file's name without extension
+                string fileName = Path.GetFileNameWithoutExtension(soundFile.Key);
+                // since Android sound names are s0001, s0002 and etc, we'll try to find its real name in sound bank from its handle in file's name
+                if (fileName.StartsWith('s') && fileName.Length >= 5 && uint.TryParse(fileName.Substring(1), out uint fileHandle))
+                {
+                    if (NebulaCore.PackageData.SoundBank.Sounds.ContainsKey(fileHandle))
+                    {
+                        var sound = NebulaCore.PackageData.SoundBank.Sounds[fileHandle]; 
+                        sound.Data = soundFile.Value;
+                        sound.Flags["PlayFromDisk"] = false;
+                        continue;
+                    }
+                }
+            }            
         }
 
         private void loadIcons(Bitmap bmp)


### PR DESCRIPTION
- Fixed float expressions;
- Fixed path to ccn file in APK reader (should've used FullName for folder "assets", but wrote Name instead, my bad);
- Added font and sound reader functionality: it can now add to sound and font banks, also can dump them (for versions from 290 and lower implementing ParameterSample as 296 version for functionality);
- Shader support for Android was added back (there's still some issues with it because some games that was ported to Android will cause troubles with certain frames, so you need to find this/these frame(s) and remove (or if you know what shader - choose it) shader from it).