### PR TITLE
Misc Fixes for Android and others

### DIFF
--- a/Nebula.Core/Data/Chunks/AppChunks/EngineVer.cs
+++ b/Nebula.Core/Data/Chunks/AppChunks/EngineVer.cs
@@ -26,7 +26,7 @@ namespace Nebula.Core.Data.Chunks.AppChunks
             EngineSubversion = reader.ReadInt();
             EngineInfo.Value = reader.ReadUInt();
 
-            if (NebulaCore.Build != EngineVersion)
+            if (NebulaCore.Build != EngineVersion && Parameters.OverrideRuntimeVersion == -1)
             {
                 this.Log($"Build was modified from {EngineVersion}.{EngineSubversion} to {NebulaCore.Build}, reverting.", Spectre.Console.Color.Yellow3_1);
                 NebulaCore.Build = EngineVersion;

--- a/Nebula.Core/Data/Chunks/BankChunks/Fonts/Font.cs
+++ b/Nebula.Core/Data/Chunks/BankChunks/Fonts/Font.cs
@@ -83,10 +83,7 @@ namespace Nebula.Core.Data.Chunks.BankChunks.Fonts
             ClipPrecision = dataReader.ReadByte();
             Quality = dataReader.ReadByte();
             PitchAndFamily = dataReader.ReadByte();
-            if (NebulaCore.Android)
-                Name = dataReader.ReadYuniversal(32); // fixed length for Android font names
-            else
-                Name = dataReader.ReadYuniversal();
+            Name = dataReader.ReadYuniversal(32);
         }
 
         public override void ReadMFA(ByteReader reader, params object[] extraInfo)

--- a/Nebula.Core/Data/Chunks/BankChunks/Sounds/Sound.cs
+++ b/Nebula.Core/Data/Chunks/BankChunks/Sounds/Sound.cs
@@ -33,14 +33,22 @@ namespace Nebula.Core.Data.Chunks.BankChunks.Sounds
             if (NebulaCore.Android)
             {
                 Handle = reader.ReadUShort();
+                string internalFilename = "s" + Handle.ToString("D4");
+                
                 Flags.Value = reader.ReadUShort();
                 reader.Skip(4);
                 Frequency = reader.ReadInt();
+                
                 if (Flags["HasName"])
                     Name = reader.ReadYuniversal(reader.ReadShort());
-                else
-                    Name = "S" + Handle.ToString("D4");
+                
+                if (string.IsNullOrEmpty(Name) && SoundBank.ExternalFiles.TryGetValue(Handle.ToString(), out var nameEntry))
+                    Name = (string)nameEntry;
 
+                if (SoundBank.ExternalFiles.TryGetValue(internalFilename, out var dataEntry)) {
+                    Data = (byte[])dataEntry;
+                    SoundBank.ExternalFiles.Remove(internalFilename);
+                }
                 return;
             }
             else if (NebulaCore.iOS)
@@ -138,18 +146,13 @@ namespace Nebula.Core.Data.Chunks.BankChunks.Sounds
             writer.WriteUInt(Handle + 1);
             writer.WriteInt(Checksum);
             writer.WriteUInt(References);
-            writer.WriteInt(Data.Length + (Flags["PlayFromDisk"] ? 0 : Name.Length * 2 + 2));
+            //writer.WriteInt(Data.Length + (Flags["PlayFromDisk"] ? 0 : Name.Length * 2 + 2));
+            writer.WriteInt(Data.Length + (Name.Length * 2 + 2));
             writer.WriteUInt(Flags.Value);
             writer.WriteInt(Frequency);
             writer.WriteInt(Name.Length + 1);
-
-            if (Flags["PlayFromDisk"])
-                writer.WriteBytes(Data);
-            else
-            {
-                writer.WriteYunicode(Name, true);
-                writer.WriteBytes(Data);
-            }
+            writer.WriteYunicode(Name, true);
+            writer.WriteBytes(Data);
         }
 
         public static byte[] FixSoundData(byte[] data)

--- a/Nebula.Core/Data/Chunks/BankChunks/Sounds/SoundBank.cs
+++ b/Nebula.Core/Data/Chunks/BankChunks/Sounds/SoundBank.cs
@@ -6,6 +6,7 @@ namespace Nebula.Core.Data.Chunks.BankChunks.Sounds
 {
     public class SoundBank : Chunk
     {
+        public static Dictionary<string, object> ExternalFiles = new(); // dictionary for saving each founded sound
         public static List<ParameterSample> SampleParameters = new();
         
         public int Count;

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/Expressions/ExpressionDouble.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/Expressions/ExpressionDouble.cs
@@ -15,17 +15,8 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
 
         public override void ReadCCN(ByteReader reader, params object[] extraInfo)
         {
-            if (NebulaCore.Windows)
-            {
-                Value = reader.ReadDouble();
-                Value2 = reader.ReadFloat();
-            }
-            else
-            {
-                reader.Skip(8); // skipping 8 bytes for getting real value
-                Value2 = reader.ReadFloat(); // fully reads float expression
-                Value = Math.Round((double)Value2, 5); // rounding the value for preventing a lot of floating-point numbers
-            }
+            Value = Math.Round(reader.ReadDouble(), 5);
+            Value2 = (float)Math.Round(reader.ReadFloat(), 5);
         }
 
         public override void WriteMFA(ByteWriter writer, params object[] extraInfo)

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterSample.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterSample.cs
@@ -1,5 +1,6 @@
 ﻿using Nebula.Core.Data.Chunks.BankChunks.Sounds;
 using Nebula.Core.Memory;
+using Nebula.Core.Utilities;
 
 namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
 {
@@ -21,10 +22,12 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
         {
             Handle = reader.ReadShort();
             SampleFlags.Value = reader.ReadUShort();
-            if (NebulaCore.Build >= 296 && (NebulaCore.Windows || NebulaCore.Android) && NebulaCore.Fusion >= 2.5 || NebulaCore.Android && NebulaCore.Build <= 290)
+            if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5)
                 SoundBank.SampleParameters.Add(this);
-            else
+            else {
                 Name = reader.ReadYuniversal();
+                SoundBank.ExternalFiles[Handle.ToString()] = Name;
+            }
         }
 
         public override void WriteMFA(ByteWriter writer, params object[] extraInfo)

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterSample.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterSample.cs
@@ -22,7 +22,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
         {
             Handle = reader.ReadShort();
             SampleFlags.Value = reader.ReadUShort();
-            if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5)
+            if (NebulaCore.Build >= 296 && (NebulaCore.Windows || NebulaCore.Android) && NebulaCore.Fusion >= 2.5)
                 SoundBank.SampleParameters.Add(this);
             else {
                 Name = reader.ReadYuniversal();

--- a/Nebula.Core/Data/Chunks/ObjectChunks/ObjectCommon/ObjectCommon.cs
+++ b/Nebula.Core/Data/Chunks/ObjectChunks/ObjectCommon/ObjectCommon.cs
@@ -242,16 +242,13 @@ namespace Nebula.Core.Data.Chunks.ObjectChunks.ObjectCommon
 
             if (NebulaCore.Android)
             {
-                // fixes 1 game, cannot be right
-                bool isEditedLayout = NebulaCore.Build == 284 || NebulaCore.Build >= 292;
-                
                 switch (index)
                 {
                     case 0:
                         MovementsOffset = Offset;
                         break;
                     case 1:
-                        if (isEditedLayout)
+                        if (NebulaCore.Build >= 284)
                             AlterableValuesOffset = Offset;
                         else
                             AnimationOffset = Offset;
@@ -263,24 +260,24 @@ namespace Nebula.Core.Data.Chunks.ObjectChunks.ObjectCommon
                         DataOffset = Offset;
                         break;
                     case 5:
-                        if (isEditedLayout)
+                        if (NebulaCore.Build >= 284)
                             ExtensionOffset = Offset;
                         else return;
                         break;
                     case 6:
-                        if (isEditedLayout)
+                        if (NebulaCore.Build >= 284)
                             AnimationOffset = Offset;
                         else
                             ExtensionOffset = Offset;
                         break;
                     case 7:
-                        if (isEditedLayout)
+                        if (NebulaCore.Build >= 284)
                             return;
                         else
                             AlterableValuesOffset = Offset;
                         break;
                     case 8:
-                        if (isEditedLayout)
+                        if (NebulaCore.Build >= 284)
                             return;
                         else
                             AlterableStringsOffset = Offset;

--- a/Nebula.Core/Data/Chunks/ObjectChunks/ObjectCommon/ObjectCommon.cs
+++ b/Nebula.Core/Data/Chunks/ObjectChunks/ObjectCommon/ObjectCommon.cs
@@ -242,13 +242,16 @@ namespace Nebula.Core.Data.Chunks.ObjectChunks.ObjectCommon
 
             if (NebulaCore.Android)
             {
+                // fixes 1 game, cannot be right
+                bool isEditedLayout = NebulaCore.Build == 284 || NebulaCore.Build >= 292;
+                
                 switch (index)
                 {
                     case 0:
                         MovementsOffset = Offset;
                         break;
                     case 1:
-                        if (NebulaCore.Build >= 284)
+                        if (isEditedLayout)
                             AlterableValuesOffset = Offset;
                         else
                             AnimationOffset = Offset;
@@ -260,24 +263,24 @@ namespace Nebula.Core.Data.Chunks.ObjectChunks.ObjectCommon
                         DataOffset = Offset;
                         break;
                     case 5:
-                        if (NebulaCore.Build >= 284)
+                        if (isEditedLayout)
                             ExtensionOffset = Offset;
                         else return;
                         break;
                     case 6:
-                        if (NebulaCore.Build >= 284)
+                        if (isEditedLayout)
                             AnimationOffset = Offset;
                         else
                             ExtensionOffset = Offset;
                         break;
                     case 7:
-                        if (NebulaCore.Build >= 284)
+                        if (isEditedLayout)
                             return;
                         else
                             AlterableValuesOffset = Offset;
                         break;
                     case 8:
-                        if (NebulaCore.Build >= 284)
+                        if (isEditedLayout)
                             return;
                         else
                             AlterableStringsOffset = Offset;

--- a/Nebula.Core/Data/PackageReaders/CCNPackageData.cs
+++ b/Nebula.Core/Data/PackageReaders/CCNPackageData.cs
@@ -21,6 +21,13 @@ namespace Nebula.Core.Data.PackageReaders
             ProductVersion = reader.ReadInt();
             ProductBuild = reader.ReadInt();
             NebulaCore.Build = ProductBuild;
+
+            if (Parameters.OverrideRuntimeVersion != -1)
+            {
+                this.Log($"Overriding build version from {NebulaCore.Build} to {Parameters.OverrideRuntimeVersion}", Spectre.Console.Color.Yellow3_1);
+                NebulaCore.Build = Parameters.OverrideRuntimeVersion;
+            }
+
             if (RuntimeVersion != 769)
             {
                 if (NebulaCore.Build < 280)

--- a/Nebula.Core/FileReaders/APKFileReader.cs
+++ b/Nebula.Core/FileReaders/APKFileReader.cs
@@ -1,4 +1,5 @@
 ﻿using Nebula.Core.Data;
+using Nebula.Core.Data.Chunks.BankChunks.Sounds;
 using Nebula.Core.Data.Chunks.BankChunks.TrueTypeFonts;
 using Nebula.Core.Data.PackageReaders;
 using Nebula.Core.Memory;
@@ -13,8 +14,6 @@ namespace Nebula.Core.FileReaders
         public string Name => "APK";
         public Dictionary<int, Bitmap> Icons { get { return _icons; } set { _icons = value; } }
         private Dictionary<int, Bitmap> _icons = new Dictionary<int, Bitmap>();
-
-        Dictionary<string, byte[]> soundFiles = new(); // dictionary for saving each founded sound
 
         public string FilePath { get { return _filePath; } set { _filePath = value; } }
         public string _filePath = string.Empty;
@@ -46,7 +45,7 @@ namespace Nebula.Core.FileReaders
                     {
                         using MemoryStream ms = new();
                         entry.Open().CopyTo(ms);
-                        soundFiles[entry.Name] = ms.ToArray(); // saving it to dictionary
+                        SoundBank.ExternalFiles[Path.GetFileNameWithoutExtension(entry.Name)] = ms.ToArray(); // saving it to dictionary
                     }
                 }
                 if (Directory.GetParent(entry.FullName)?.Name == "fonts" && Path.GetExtension(entry.Name) == ".ttf")
@@ -70,7 +69,6 @@ namespace Nebula.Core.FileReaders
             {
                 NebulaCore.Android = true; // flag is needed for fixing some issues
                 Package.Read(ccnReader);
-                LoadAndroidSounds(soundFiles); // put here for fixing issues with sound dumping
             }
         }
 
@@ -89,29 +87,6 @@ namespace Nebula.Core.FileReaders
             NebulaCore.PackageData.TrueTypeFontBank.Fonts.Add(ttf); // then add font to the bank
         }
 
-        private void LoadAndroidSounds(Dictionary<string, byte[]> soundFiles)
-        {
-            // no sounds - skip
-            if (soundFiles.Count == 0 || NebulaCore.PackageData.SoundBank.Sounds.Count == 0)
-                return;
-
-            foreach (var soundFile in soundFiles)
-            {
-                // getting file's name without extension
-                string fileName = Path.GetFileNameWithoutExtension(soundFile.Key).ToLower();
-                // since Android sound names are s0001, s0002 and etc, we'll try to find its real name in sound bank from its handle in file's name
-                if (fileName.StartsWith('s') && fileName.Length >= 5 && uint.TryParse(fileName.Substring(1), out uint fileHandle))
-                {
-                    if (NebulaCore.PackageData.SoundBank.Sounds.ContainsKey(fileHandle))
-                    {
-                        var sound = NebulaCore.PackageData.SoundBank.Sounds[fileHandle]; 
-                        sound.Data = soundFile.Value;
-                        sound.Flags["PlayFromDisk"] = false;
-                        continue;
-                    }
-                }
-            }            
-        }
 
         private void loadIcons(Bitmap bmp)
         {

--- a/Nebula.Core/Memory/ByteReader.cs
+++ b/Nebula.Core/Memory/ByteReader.cs
@@ -89,7 +89,12 @@ namespace Nebula.Core.Memory
         public float ReadFloat() => ReadSingle();
         public bool ReadBool() => ReadByte() == 1;
 
-        public override double ReadDouble() => ReadLong() / 4294967296.0;
+        public override double ReadDouble()
+        {
+            if (!NebulaCore.Windows)
+                return ReadLong() / 4294967296.0;
+            return base.ReadDouble();
+        }
 
         public string ReadAscii(int length = -1)
         {

--- a/Nebula.Core/Memory/ByteReader.cs
+++ b/Nebula.Core/Memory/ByteReader.cs
@@ -78,6 +78,26 @@ namespace Nebula.Core.Memory
         public float ReadFloat() => ReadSingle();
         public bool ReadBool() => ReadByte() == 1;
 
+        public override double ReadDouble()
+        {
+            // Copied from XNA / Other runtime implementations
+            int b1 = ReadByte();
+            int b2 = ReadByte();
+            int b3 = ReadByte();
+            int b4 = ReadByte();
+            int b5 = ReadByte();
+            int b6 = ReadByte();
+            int b7 = ReadByte();
+            int b8 = ReadByte();
+
+            long total1 = ((long)b4 << 24) | ((long)b3 << 16) | ((long)b2 << 8) | b1;
+            long total2 = ((long)b8 << 24) | ((long)b7 << 16) | ((long)b6 << 8) | b5;
+
+            long total = (total2 << 32) | (total1 & 0xFFFFFFFFL);
+
+            return total / 4294967296.0; // 2^32
+        }
+
         public string ReadAscii(int length = -1)
         {
             string str = "";

--- a/Nebula.Core/Memory/ByteReader.cs
+++ b/Nebula.Core/Memory/ByteReader.cs
@@ -58,6 +58,13 @@ namespace Nebula.Core.Memory
             return value;
         }
 
+        public ulong PeekUInt64()
+        {
+            ulong value = ReadULong();
+            Skip(-8);
+            return value;
+        }
+
         public float PeekSingle()
         {
             float value = ReadFloat();
@@ -70,33 +77,19 @@ namespace Nebula.Core.Memory
         public uint PeekUInt() => PeekUInt32();
         public int PeekInt() => PeekInt32();
         public float PeekFloat() => PeekSingle();
+        public long PeekLong() => PeekInt64();
+        public ulong PeekULong() => PeekUInt64();
 
         public ushort ReadUShort() => ReadUInt16();
         public short ReadShort() => ReadInt16();
         public uint ReadUInt() => ReadUInt32();
         public int ReadInt() => ReadInt32();
+        public long ReadLong() => ReadInt64();
+        public ulong ReadULong() => ReadUInt64();
         public float ReadFloat() => ReadSingle();
         public bool ReadBool() => ReadByte() == 1;
 
-        public override double ReadDouble()
-        {
-            // Copied from XNA / Other runtime implementations
-            int b1 = ReadByte();
-            int b2 = ReadByte();
-            int b3 = ReadByte();
-            int b4 = ReadByte();
-            int b5 = ReadByte();
-            int b6 = ReadByte();
-            int b7 = ReadByte();
-            int b8 = ReadByte();
-
-            long total1 = ((long)b4 << 24) | ((long)b3 << 16) | ((long)b2 << 8) | b1;
-            long total2 = ((long)b8 << 24) | ((long)b7 << 16) | ((long)b6 << 8) | b5;
-
-            long total = (total2 << 32) | (total1 & 0xFFFFFFFFL);
-
-            return total / 4294967296.0; // 2^32
-        }
+        public override double ReadDouble() => ReadLong() / 4294967296.0;
 
         public string ReadAscii(int length = -1)
         {

--- a/Nebula.Core/Utilities/Parameters.cs
+++ b/Nebula.Core/Utilities/Parameters.cs
@@ -29,6 +29,8 @@ namespace Nebula.Core.Utilities
         public bool force_unicode = false;
         public string comment_header = "Whether or not to avoid using the header for text encoding";
         public bool ignore_header = false;
+        public string comment_override_runtime_version = "Override the runtime version";
+        public int override_runtime_version = -1;
         public string comment_image_reader = "Whether or not to force reading images with the 2.5 reader rather than the 2.5+ reader";
         public bool force_image_reader = false;
         public string comment_gpu = "Whether or not to use the GPU to translate images (EXPERIMENTAL)";
@@ -39,8 +41,6 @@ namespace Nebula.Core.Utilities
         public bool invert_ignore_frames = false;
         public string comment_frames = "An array of frame ids to ignore reading, index starts at 0";
         public int[] ignore_frames = new int[0];
-        public string comment_override_runtime_version = "Override the runtime version";
-        public int override_runtime_version = -1;
 
         public Parameters()
         {
@@ -65,11 +65,11 @@ namespace Nebula.Core.Utilities
         public static bool DumpAllChunks => Inst.dump_all_chunks;
         public static bool ForceUnicode => Inst.force_unicode;
         public static bool IgnoreHeader => Inst.ignore_header;
+        public static int OverrideRuntimeVersion => Inst.override_runtime_version;
         public static bool GPUAcceleration => Inst.gpu_acceleration;
         public static bool ForceImageReader => Inst.force_image_reader;
         public static bool SilentLogEvents => Inst.silent_log_events;
         public static bool InvertFrameMask => Inst.invert_ignore_frames;
         public static int[] DontIncludeFrames => Inst.ignore_frames;
-        public static int OverrideRuntimeVersion => Inst.override_runtime_version;
     }
 }

--- a/Nebula.Core/Utilities/Parameters.cs
+++ b/Nebula.Core/Utilities/Parameters.cs
@@ -39,6 +39,8 @@ namespace Nebula.Core.Utilities
         public bool invert_ignore_frames = false;
         public string comment_frames = "An array of frame ids to ignore reading, index starts at 0";
         public int[] ignore_frames = new int[0];
+        public string comment_override_runtime_version = "Override the runtime version";
+        public int override_runtime_version = -1;
 
         public Parameters()
         {
@@ -68,5 +70,6 @@ namespace Nebula.Core.Utilities
         public static bool SilentLogEvents => Inst.silent_log_events;
         public static bool InvertFrameMask => Inst.invert_ignore_frames;
         public static int[] DontIncludeFrames => Inst.ignore_frames;
+        public static int OverrideRuntimeVersion => Inst.override_runtime_version;
     }
 }


### PR DESCRIPTION
Changed Font Name If statement to just use `ReadYuniversal(32)`. 

Changed how the APK sounds are stored:
I didn't like how the previous PR got the sounds. it changed all the sounds to the s0XXX naming and not their actual names.  I renamed their storage variable to `ExternalFiles` and put it in soundbank as static. I also changed how it writes the sound to the mfa. it had garbage bytes due to playfromdisk flag changes it does to the mfa.

Added ReadDouble to read the double format correctly.  Exactly how the XNA and current Android runtimes do. cSharps ReadDouble didn't interpolate the format correctly.

Small object common "fix" for one game. i hate it.. must have explanation for why they changed it for that version of the runtime.
