### PR TITLE
Qualifier 296 fix + small Android and iOS support update

### DIFF
--- a/Nebula.CLI/Program.cs
+++ b/Nebula.CLI/Program.cs
@@ -129,6 +129,7 @@ namespace Nebula
                 case ".zip":
                     NebulaCore.CurrentReader = new OpenFileReader();
                     break;
+                case ".xapk":
                 case ".apk":
                     NebulaCore.CurrentReader = new APKFileReader();
                     break;

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/ACEventBase.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/ACEventBase.cs
@@ -42,6 +42,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
 
         public Event Parent = null;
         public bool DoAdd = true;
+        public bool Fusion296PC = NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5; // needed for checkings here and in ParameterObject.cs for qualifiers
 
         public override void ReadCCN(ByteReader reader, params object[] extraInfo)
         {
@@ -65,6 +66,9 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
 
         public ObjectInfo? GetObject()
         {
+	    // same as in ParameterObject.cs
+            if (Fusion296PC && (ObjectInfo & 0x8000) != 0)
+                return null;
             if (Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
                 return null;
             else if (NebulaCore.MFA && Parent?.Parent.EventObjects.Count > 0)
@@ -292,6 +296,13 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
             Qualifier[] qualifier = Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).ToArray()!;
             if (qualifier.Length > 0)
                 return GetQualifierName(qualifier.First());
+            // same thing as in ParameterObject.cs, also fixes for not finding some other qualifiers in some actions and conditions
+            if (Fusion296PC && (ObjectInfo & 0x8000) != 0)
+            {
+                Qualifier? newQualifier = new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType };
+                Parent?.Parent.Qualifiers.Add(newQualifier);
+                return GetQualifierName(newQualifier);
+            }
             return "Unknown Object";
         }
 

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/ACEventBase.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/ACEventBase.cs
@@ -65,7 +65,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
 
         public ObjectInfo? GetObject()
         {
-            return ObjectCommon.GetObject(ObjectInfo, ObjectType, this, null);
+            return ObjectCommon.GetObjectACEventBase(ObjectInfo, ObjectType, this);
         }
 
         public string GetGlobalValueName(ParameterChunk param)

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/ACEventBase.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/ACEventBase.cs
@@ -289,8 +289,140 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
             ObjectInfo? objectInfo = GetObject();
             if (objectInfo != null)
                 return objectInfo.Name;
+            Qualifier[] qualifier = Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).ToArray()!;
+            if (qualifier.Length > 0)
+                return GetQualifierName(qualifier.First());
+            return "Unknown Object";
+        }
+
+        public string GetQualifierName(Qualifier qualifier)
+        {
+            string qualifierName = "Group." + (qualifier.ObjectInfo & 0x7FFF) switch
+            {
+                0 => "Player",
+                1 => "Good",
+                2 => "Neutral",
+                3 => "Bad",
+                4 => "Enemies",
+                5 => "Friends",
+                6 => "Bullets",
+                7 => "Arms",
+                8 => "Bonus",
+                9 => "Collectables",
+                10 => "Traps",
+                11 => "Doors",
+                12 => "Keys",
+                13 => "Texts",
+                14 => "0",
+                15 => "1",
+                16 => "2",
+                17 => "3",
+                18 => "4",
+                19 => "5",
+                20 => "6",
+                21 => "7",
+                22 => "8",
+                23 => "9",
+                24 => "Parents",
+                25 => "Children",
+                26 => "Data",
+                27 => "Timed",
+                28 => "Engine",
+                29 => "Areas",
+                30 => "Reference Points",
+                31 => "Radar Enemies",
+                32 => "Radar Friends",
+                33 => "Radar Neutrals",
+                34 => "Music",
+                35 => "Sound",
+                36 => "Waveform",
+                37 => "Background Scenery",
+                38 => "Foreground Scenery",
+                39 => "Decorations",
+                40 => "Water",
+                41 => "Clouds",
+                42 => "Empty",
+                43 => "Fog",
+                44 => "Flowers",
+                45 => "Animals",
+                46 => "Bosses",
+                47 => "NPC",
+                48 => "Vehicles",
+                49 => "Rockets",
+                50 => "Balls",
+                51 => "Bombs",
+                52 => "Explosions",
+                53 => "Particles",
+                54 => "Clothes",
+                55 => "Glow",
+                56 => "Arrows",
+                57 => "Buttons",
+                58 => "Cursors",
+                59 => "Drawing Tools",
+                60 => "Indicator",
+                61 => "Shapes",
+                62 => "Shields",
+                63 => "Shifting Blocks",
+                64 => "Magnets",
+                65 => "Negative Matter",
+                66 => "Neutral Matter",
+                67 => "Positive Matter",
+                68 => "Breakable",
+                69 => "Dissolving",
+                70 => "Dialogue",
+                71 => "HUD",
+                72 => "Inventory",
+                73 => "Inventory Item",
+                74 => "Interface",
+                75 => "Movable",
+                76 => "Perspective",
+                77 => "Calculation Objects",
+                78 => "Invisible",
+                79 => "Masks",
+                80 => "Obstacles",
+                81 => "Value Holder",
+                82 => "Helpful",
+                83 => "Powerups",
+                84 => "Targets",
+                85 => "Trapdoors",
+                86 => "Dangers",
+                87 => "Forbidden",
+                88 => "Physical objects",
+                89 => "3D Objects",
+                90 => "Generic 1",
+                91 => "Generic 2",
+                92 => "Generic 3",
+                93 => "Generic 4",
+                94 => "Generic 5",
+                95 => "Generic 6",
+                96 => "Generic 7",
+                97 => "Generic 8",
+                98 => "Generic 9",
+                99 => "Generic 10",
+                _ => string.Empty
+            };
+
+            qualifierName += "." + qualifier.Type switch
+            {
+                2 => "Sprite",
+                3 => "Text",
+                4 => "Question",
+                5 => "Score",
+                6 => "Lives",
+                7 => "Counter",
+                _ => string.Empty
+            };
+
+            if (qualifier.Type >= 32 && NebulaCore.PackageData.Extensions.Exts.ContainsKey(qualifier.Type - 32))
+            {
+                Extension ext = NebulaCore.PackageData.Extensions.Exts[qualifier.Type - 32];
+                qualifierName += ext.Name;
+            }
+
+            if (qualifierName.StartsWith("Group.."))
+                return "Unknown Qualifier";
             else
-                return ObjectCommon.TryGetQualifierACE(this, ObjectInfo, ObjectType);
+                return qualifierName;
         }
 
         public string GetDirection(ParameterChunk param)

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/ACEventBase.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/ACEventBase.cs
@@ -65,7 +65,12 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
 
         public ObjectInfo? GetObject()
         {
-            return ObjectCommon.GetObjectACEventBase(ObjectInfo, ObjectType, this);
+            if (Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
+                return null;
+            else if (NebulaCore.MFA && Parent?.Parent.EventObjects.Count > 0)
+                return NebulaCore.PackageData.FrameItems.Items[(int)Parent.Parent.EventObjects[ObjectInfo].ItemHandle];
+            else
+                return NebulaCore.PackageData.FrameItems.Items[ObjectInfo];
         }
 
         public string GetGlobalValueName(ParameterChunk param)
@@ -284,140 +289,8 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
             ObjectInfo? objectInfo = GetObject();
             if (objectInfo != null)
                 return objectInfo.Name;
-            Qualifier[] qualifier = Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).ToArray()!;
-            if (qualifier.Length > 0)
-                return GetQualifierName(qualifier.First());
-            return "Unknown Object";
-        }
-
-        public string GetQualifierName(Qualifier qualifier)
-        {
-            string qualifierName = "Group." + (qualifier.ObjectInfo & 0x7FFF) switch
-            {
-                0 => "Player",
-                1 => "Good",
-                2 => "Neutral",
-                3 => "Bad",
-                4 => "Enemies",
-                5 => "Friends",
-                6 => "Bullets",
-                7 => "Arms",
-                8 => "Bonus",
-                9 => "Collectables",
-                10 => "Traps",
-                11 => "Doors",
-                12 => "Keys",
-                13 => "Texts",
-                14 => "0",
-                15 => "1",
-                16 => "2",
-                17 => "3",
-                18 => "4",
-                19 => "5",
-                20 => "6",
-                21 => "7",
-                22 => "8",
-                23 => "9",
-                24 => "Parents",
-                25 => "Children",
-                26 => "Data",
-                27 => "Timed",
-                28 => "Engine",
-                29 => "Areas",
-                30 => "Reference Points",
-                31 => "Radar Enemies",
-                32 => "Radar Friends",
-                33 => "Radar Neutrals",
-                34 => "Music",
-                35 => "Sound",
-                36 => "Waveform",
-                37 => "Background Scenery",
-                38 => "Foreground Scenery",
-                39 => "Decorations",
-                40 => "Water",
-                41 => "Clouds",
-                42 => "Empty",
-                43 => "Fog",
-                44 => "Flowers",
-                45 => "Animals",
-                46 => "Bosses",
-                47 => "NPC",
-                48 => "Vehicles",
-                49 => "Rockets",
-                50 => "Balls",
-                51 => "Bombs",
-                52 => "Explosions",
-                53 => "Particles",
-                54 => "Clothes",
-                55 => "Glow",
-                56 => "Arrows",
-                57 => "Buttons",
-                58 => "Cursors",
-                59 => "Drawing Tools",
-                60 => "Indicator",
-                61 => "Shapes",
-                62 => "Shields",
-                63 => "Shifting Blocks",
-                64 => "Magnets",
-                65 => "Negative Matter",
-                66 => "Neutral Matter",
-                67 => "Positive Matter",
-                68 => "Breakable",
-                69 => "Dissolving",
-                70 => "Dialogue",
-                71 => "HUD",
-                72 => "Inventory",
-                73 => "Inventory Item",
-                74 => "Interface",
-                75 => "Movable",
-                76 => "Perspective",
-                77 => "Calculation Objects",
-                78 => "Invisible",
-                79 => "Masks",
-                80 => "Obstacles",
-                81 => "Value Holder",
-                82 => "Helpful",
-                83 => "Powerups",
-                84 => "Targets",
-                85 => "Trapdoors",
-                86 => "Dangers",
-                87 => "Forbidden",
-                88 => "Physical objects",
-                89 => "3D Objects",
-                90 => "Generic 1",
-                91 => "Generic 2",
-                92 => "Generic 3",
-                93 => "Generic 4",
-                94 => "Generic 5",
-                95 => "Generic 6",
-                96 => "Generic 7",
-                97 => "Generic 8",
-                98 => "Generic 9",
-                99 => "Generic 10",
-                _ => string.Empty
-            };
-
-            qualifierName += "." + qualifier.Type switch
-            {
-                2 => "Sprite",
-                3 => "Text",
-                4 => "Question",
-                5 => "Score",
-                6 => "Lives",
-                7 => "Counter",
-                _ => string.Empty
-            };
-
-            if (qualifier.Type >= 32 && NebulaCore.PackageData.Extensions.Exts.ContainsKey(qualifier.Type - 32))
-            {
-                Extension ext = NebulaCore.PackageData.Extensions.Exts[qualifier.Type - 32];
-                qualifierName += ext.Name;
-            }
-
-            if (qualifierName.StartsWith("Group.."))
-                return "Unknown Qualifier";
             else
-                return qualifierName;
+                return ObjectCommon.TryGetQualifierACE(this, ObjectInfo, ObjectType);
         }
 
         public string GetDirection(ParameterChunk param)

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/ACEventBase.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/ACEventBase.cs
@@ -65,9 +65,6 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
 
         public ObjectInfo? GetObject()
         {
-	    // same as in ParameterObject.cs
-            if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
-                return null;
             if (Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
                 return null;
             else if (NebulaCore.MFA && Parent?.Parent.EventObjects.Count > 0)
@@ -295,13 +292,6 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
             Qualifier[] qualifier = Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).ToArray()!;
             if (qualifier.Length > 0)
                 return GetQualifierName(qualifier.First());
-            // same thing as in ParameterObject.cs, also fixes for not finding some other qualifiers in some actions and conditions
-            if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
-            {
-                Qualifier? newQualifier = new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType };
-                Parent?.Parent.Qualifiers.Add(newQualifier);
-                return GetQualifierName(newQualifier);
-            }
             return "Unknown Object";
         }
 

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/ACEventBase.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/ACEventBase.cs
@@ -65,7 +65,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
 
         public ObjectInfo? GetObject()
         {
-            return ObjectCommon.GetObjectACEventBase(ObjectInfo, ObjectType, this);
+            return ObjectCommon.GetObject(ObjectInfo, ObjectType, this, null);
         }
 
         public string GetGlobalValueName(ParameterChunk param)

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/ACEventBase.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/ACEventBase.cs
@@ -42,7 +42,6 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
 
         public Event Parent = null;
         public bool DoAdd = true;
-        public bool Fusion296PC = NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5; // needed for checkings here and in ParameterObject.cs for qualifiers
 
         public override void ReadCCN(ByteReader reader, params object[] extraInfo)
         {
@@ -67,7 +66,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
         public ObjectInfo? GetObject()
         {
 	    // same as in ParameterObject.cs
-            if (Fusion296PC && (ObjectInfo & 0x8000) != 0)
+            if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
                 return null;
             if (Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
                 return null;
@@ -297,7 +296,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
             if (qualifier.Length > 0)
                 return GetQualifierName(qualifier.First());
             // same thing as in ParameterObject.cs, also fixes for not finding some other qualifiers in some actions and conditions
-            if (Fusion296PC && (ObjectInfo & 0x8000) != 0)
+            if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
             {
                 Qualifier? newQualifier = new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType };
                 Parent?.Parent.Qualifiers.Add(newQualifier);

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/ACEventBase.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/ACEventBase.cs
@@ -65,12 +65,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
 
         public ObjectInfo? GetObject()
         {
-            if (Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
-                return null;
-            else if (NebulaCore.MFA && Parent?.Parent.EventObjects.Count > 0)
-                return NebulaCore.PackageData.FrameItems.Items[(int)Parent.Parent.EventObjects[ObjectInfo].ItemHandle];
-            else
-                return NebulaCore.PackageData.FrameItems.Items[ObjectInfo];
+            return ObjectCommon.GetObjectACEventBase(ObjectInfo, ObjectType, this);
         }
 
         public string GetGlobalValueName(ParameterChunk param)

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Action.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Action.cs
@@ -45,30 +45,10 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
 			}
 			else
 			{
-                if (ObjectType == -7 || ObjectType >= 0)
-                {
-                    ObjectInfo = reader.ReadUShort();
-                    if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
-                    {
-                        bool exists = Parent?.Parent?.Qualifiers.Where(q => q.ObjectInfo == ObjectInfo && q.Type == ObjectType).Any() == true;
-                        if (!exists)
-                            Parent?.Parent?.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType });
-                        bool doAdd = true;
-                        foreach (Qualifier qualifier in Parent.Parent.Qualifiers)
-                            if (qualifier.ObjectInfo == ObjectInfo && qualifier.Type == ObjectType)
-                                doAdd = false; // throw new Exception("Adding duplicate qualifiers to the qualifier list!");
+				if (ObjectType == -7 || ObjectType >= 0)
+					ObjectInfo = reader.ReadUShort();
 
-                        if (doAdd)
-                            Parent.Parent.Qualifiers.Add(new Qualifier()
-                            {
-                                ObjectInfo = ObjectInfo,
-                                Type = ObjectType
-                            });
-                    }
-                }
-                    
-
-                Flags296.Value = reader.ReadByte();
+				Flags296.Value = reader.ReadByte();
 				EventFlags["Always"] = Flags296["Always"];
 				EventFlags["Repeat"] = Flags296["Repeat"];
 				OtherFlags["Negated"] = Flags296["Negated"];
@@ -79,8 +59,24 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
 					Parameters[i] = new Parameter();
 					Parameters[i].ReadCCN(reader);
 					Parameters[i].FrameEvents = Parent.Parent;
-                }
-            }
+				}
+
+				// Qualifier
+				if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
+                {
+                    bool doAdd = true;
+                    foreach (Qualifier qualifier in Parent.Parent.Qualifiers)
+                        if (qualifier.ObjectInfo == ObjectInfo && qualifier.Type == ObjectType)
+                            doAdd = false; // throw new Exception("Adding duplicate qualifiers to the qualifier list!");
+
+                    if (doAdd)
+					Parent.Parent.Qualifiers.Add(new Qualifier()
+					{
+						ObjectInfo = ObjectInfo,
+						Type = ObjectType
+					});
+			    }
+			}
 
             Fix((List<Action>)extraInfo[0], reader, endPosition);
 			reader.Seek(endPosition);

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Action.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Action.cs
@@ -45,10 +45,30 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
 			}
 			else
 			{
-				if (ObjectType == -7 || ObjectType >= 0)
-					ObjectInfo = reader.ReadUShort();
+                if (ObjectType == -7 || ObjectType >= 0)
+                {
+                    ObjectInfo = reader.ReadUShort();
+                    if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
+                    {
+                        bool exists = Parent?.Parent?.Qualifiers.Where(q => q.ObjectInfo == ObjectInfo && q.Type == ObjectType).Any() == true;
+                        if (!exists)
+                            Parent?.Parent?.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType });
+                        bool doAdd = true;
+                        foreach (Qualifier qualifier in Parent.Parent.Qualifiers)
+                            if (qualifier.ObjectInfo == ObjectInfo && qualifier.Type == ObjectType)
+                                doAdd = false; // throw new Exception("Adding duplicate qualifiers to the qualifier list!");
 
-				Flags296.Value = reader.ReadByte();
+                        if (doAdd)
+                            Parent.Parent.Qualifiers.Add(new Qualifier()
+                            {
+                                ObjectInfo = ObjectInfo,
+                                Type = ObjectType
+                            });
+                    }
+                }
+                    
+
+                Flags296.Value = reader.ReadByte();
 				EventFlags["Always"] = Flags296["Always"];
 				EventFlags["Repeat"] = Flags296["Repeat"];
 				OtherFlags["Negated"] = Flags296["Negated"];
@@ -59,8 +79,8 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
 					Parameters[i] = new Parameter();
 					Parameters[i].ReadCCN(reader);
 					Parameters[i].FrameEvents = Parent.Parent;
-				}
-			}
+                }
+            }
 
             Fix((List<Action>)extraInfo[0], reader, endPosition);
 			reader.Seek(endPosition);

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Action.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Action.cs
@@ -60,22 +60,6 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
 					Parameters[i].ReadCCN(reader);
 					Parameters[i].FrameEvents = Parent.Parent;
 				}
-
-				// Qualifier
-				if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
-                {
-                    bool doAdd = true;
-                    foreach (Qualifier qualifier in Parent.Parent.Qualifiers)
-                        if (qualifier.ObjectInfo == ObjectInfo && qualifier.Type == ObjectType)
-                            doAdd = false; // throw new Exception("Adding duplicate qualifiers to the qualifier list!");
-
-                    if (doAdd)
-					Parent.Parent.Qualifiers.Add(new Qualifier()
-					{
-						ObjectInfo = ObjectInfo,
-						Type = ObjectType
-					});
-			}
 			}
 
             Fix((List<Action>)extraInfo[0], reader, endPosition);

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Condition.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Condition.cs
@@ -50,7 +50,27 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
             else
             {
                 if (ObjectType == -7 || ObjectType >= 0)
+                {
                     ObjectInfo = reader.ReadUShort();
+                    if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
+                    {
+                        bool exists = Parent?.Parent?.Qualifiers.Where(q => q.ObjectInfo == ObjectInfo && q.Type == ObjectType).Any() == true;
+                        if (!exists)
+                            Parent?.Parent?.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType });
+                        bool doAdd = true;
+                        foreach (Qualifier qualifier in Parent.Parent.Qualifiers)
+                            if (qualifier.ObjectInfo == ObjectInfo && qualifier.Type == ObjectType)
+                                doAdd = false; // throw new Exception("Adding duplicate qualifiers to the qualifier list!");
+
+                        if (doAdd)
+                            Parent.Parent.Qualifiers.Add(new Qualifier()
+                            {
+                                ObjectInfo = ObjectInfo,
+                                Type = ObjectType
+                            });
+                    }
+                }
+
                 Flags296.Value = reader.ReadByte();
                 EventFlags["Always"] = Flags296["Always"];
                 OtherFlags["NoInterdependence"] = Flags296["NoInterdependence"];
@@ -63,8 +83,8 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
 					Parameters[i] = new Parameter();
 					Parameters[i].ReadCCN(reader);
 					Parameters[i].FrameEvents = Parent.Parent;
-				}
-			}
+                }
+            }
 
             Fix((List<Condition>)extraInfo[0], reader);
             reader.Seek(endPosition);

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Condition.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Condition.cs
@@ -64,22 +64,6 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
 					Parameters[i].ReadCCN(reader);
 					Parameters[i].FrameEvents = Parent.Parent;
 				}
-
-                // Qualifier
-				if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
-				{
-					bool doAdd = true;
-					foreach (Qualifier qualifier in Parent.Parent.Qualifiers)
-						if (qualifier.ObjectInfo == ObjectInfo && qualifier.Type == ObjectType)
-							doAdd = false; // throw new Exception("Adding duplicate qualifiers to the qualifier list!");
-
-					if (doAdd)
-                    Parent.Parent.Qualifiers.Add(new Qualifier()
-                    {
-                        ObjectInfo = ObjectInfo,
-                        Type = ObjectType
-                    });
-            }
 			}
 
             Fix((List<Condition>)extraInfo[0], reader);

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Condition.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Condition.cs
@@ -50,27 +50,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
             else
             {
                 if (ObjectType == -7 || ObjectType >= 0)
-                {
                     ObjectInfo = reader.ReadUShort();
-                    if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
-                    {
-                        bool exists = Parent?.Parent?.Qualifiers.Where(q => q.ObjectInfo == ObjectInfo && q.Type == ObjectType).Any() == true;
-                        if (!exists)
-                            Parent?.Parent?.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType });
-                        bool doAdd = true;
-                        foreach (Qualifier qualifier in Parent.Parent.Qualifiers)
-                            if (qualifier.ObjectInfo == ObjectInfo && qualifier.Type == ObjectType)
-                                doAdd = false; // throw new Exception("Adding duplicate qualifiers to the qualifier list!");
-
-                        if (doAdd)
-                            Parent.Parent.Qualifiers.Add(new Qualifier()
-                            {
-                                ObjectInfo = ObjectInfo,
-                                Type = ObjectType
-                            });
-                    }
-                }
-
                 Flags296.Value = reader.ReadByte();
                 EventFlags["Always"] = Flags296["Always"];
                 OtherFlags["NoInterdependence"] = Flags296["NoInterdependence"];
@@ -83,8 +63,24 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events
 					Parameters[i] = new Parameter();
 					Parameters[i].ReadCCN(reader);
 					Parameters[i].FrameEvents = Parent.Parent;
+				}
+
+                // Qualifier
+				if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
+				{
+					bool doAdd = true;
+					foreach (Qualifier qualifier in Parent.Parent.Qualifiers)
+						if (qualifier.ObjectInfo == ObjectInfo && qualifier.Type == ObjectType)
+							doAdd = false; // throw new Exception("Adding duplicate qualifiers to the qualifier list!");
+
+					if (doAdd)
+                    Parent.Parent.Qualifiers.Add(new Qualifier()
+                    {
+                        ObjectInfo = ObjectInfo,
+                        Type = ObjectType
+                    });
                 }
-            }
+			}
 
             Fix((List<Condition>)extraInfo[0], reader);
             reader.Seek(endPosition);

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterExpression.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterExpression.cs
@@ -553,7 +553,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
 
         public ObjectInfo? GetObject()
         {
-            return ObjectCommon.GetObject(ObjectInfo, ObjectType, this);
+            return ObjectCommon.GetObject(ObjectInfo, ObjectType, null, this);
         }
 
         public string GetGlobalValueName()

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterExpression.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterExpression.cs
@@ -553,7 +553,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
 
         public ObjectInfo? GetObject()
         {
-            return ObjectCommon.GetObject(ObjectInfo, ObjectType, null, this);
+            return ObjectCommon.GetObject(ObjectInfo, ObjectType, this);
         }
 
         public string GetGlobalValueName()

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterExpression.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterExpression.cs
@@ -553,7 +553,12 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
 
         public ObjectInfo? GetObject()
         {
-            return ObjectCommon.GetObject(ObjectInfo, ObjectType, this);
+            if (Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
+                return null;
+            else if (NebulaCore.MFA && Parent?.FrameEvents?.EventObjects.Count > 0)
+                return NebulaCore.PackageData.FrameItems.Items[(int)Parent.FrameEvents.EventObjects[ObjectInfo].ItemHandle];
+            else
+                return NebulaCore.PackageData.FrameItems.Items[ObjectInfo];
         }
 
         public string GetGlobalValueName()
@@ -609,140 +614,8 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
             ObjectInfo? objectInfo = GetObject();
             if (objectInfo != null)
                 return objectInfo.Name;
-            Qualifier[] qualifier = Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).ToArray()!;
-            if (qualifier.Length > 0)
-                return GetQualifierName(qualifier.First());
-            return "Unknown Object";
-        }
-
-        public string GetQualifierName(Qualifier qualifier)
-        {
-            string qualifierName = "Group." + (qualifier.ObjectInfo & 0x7FFF) switch
-            {
-                0 => "Player",
-                1 => "Good",
-                2 => "Neutral",
-                3 => "Bad",
-                4 => "Enemies",
-                5 => "Friends",
-                6 => "Bullets",
-                7 => "Arms",
-                8 => "Bonus",
-                9 => "Collectables",
-                10 => "Traps",
-                11 => "Doors",
-                12 => "Keys",
-                13 => "Texts",
-                14 => "0",
-                15 => "1",
-                16 => "2",
-                17 => "3",
-                18 => "4",
-                19 => "5",
-                20 => "6",
-                21 => "7",
-                22 => "8",
-                23 => "9",
-                24 => "Parents",
-                25 => "Children",
-                26 => "Data",
-                27 => "Timed",
-                28 => "Engine",
-                29 => "Areas",
-                30 => "Reference Points",
-                31 => "Radar Enemies",
-                32 => "Radar Friends",
-                33 => "Radar Neutrals",
-                34 => "Music",
-                35 => "Sound",
-                36 => "Waveform",
-                37 => "Background Scenery",
-                38 => "Foreground Scenery",
-                39 => "Decorations",
-                40 => "Water",
-                41 => "Clouds",
-                42 => "Empty",
-                43 => "Fog",
-                44 => "Flowers",
-                45 => "Animals",
-                46 => "Bosses",
-                47 => "NPC",
-                48 => "Vehicles",
-                49 => "Rockets",
-                50 => "Balls",
-                51 => "Bombs",
-                52 => "Explosions",
-                53 => "Particles",
-                54 => "Clothes",
-                55 => "Glow",
-                56 => "Arrows",
-                57 => "Buttons",
-                58 => "Cursors",
-                59 => "Drawing Tools",
-                60 => "Indicator",
-                61 => "Shapes",
-                62 => "Shields",
-                63 => "Shifting Blocks",
-                64 => "Magnets",
-                65 => "Negative Matter",
-                66 => "Neutral Matter",
-                67 => "Positive Matter",
-                68 => "Breakable",
-                69 => "Dissolving",
-                70 => "Dialogue",
-                71 => "HUD",
-                72 => "Inventory",
-                73 => "Inventory Item",
-                74 => "Interface",
-                75 => "Movable",
-                76 => "Perspective",
-                77 => "Calculation Objects",
-                78 => "Invisible",
-                79 => "Masks",
-                80 => "Obstacles",
-                81 => "Value Holder",
-                82 => "Helpful",
-                83 => "Powerups",
-                84 => "Targets",
-                85 => "Trapdoors",
-                86 => "Dangers",
-                87 => "Forbidden",
-                88 => "Physical objects",
-                89 => "3D Objects",
-                90 => "Generic 1",
-                91 => "Generic 2",
-                92 => "Generic 3",
-                93 => "Generic 4",
-                94 => "Generic 5",
-                95 => "Generic 6",
-                96 => "Generic 7",
-                97 => "Generic 8",
-                98 => "Generic 9",
-                99 => "Generic 10",
-                _ => string.Empty
-            };
-
-            qualifierName += "." + qualifier.Type switch
-            {
-                2 => "Sprite",
-                3 => "Text",
-                4 => "Question",
-                5 => "Score",
-                6 => "Lives",
-                7 => "Counter",
-                _ => string.Empty
-            };
-
-            if (qualifier.Type >= 32 && NebulaCore.PackageData.Extensions.Exts.ContainsKey(qualifier.Type - 32))
-            {
-                Extension ext = NebulaCore.PackageData.Extensions.Exts[qualifier.Type - 32];
-                qualifierName += ext.Name;
-            }
-
-            if (qualifierName.StartsWith("Group.."))
-                return "Unknown Qualifier";
             else
-                return qualifierName;
+                return ObjectCommon.TryGetQualifier(this, ObjectInfo, ObjectType);
         }
     }
 }

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterExpression.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterExpression.cs
@@ -553,12 +553,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
 
         public ObjectInfo? GetObject()
         {
-            if (Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
-                return null;
-            else if (NebulaCore.MFA && Parent?.FrameEvents?.EventObjects.Count > 0)
-                return NebulaCore.PackageData.FrameItems.Items[(int)Parent.FrameEvents.EventObjects[ObjectInfo].ItemHandle];
-            else
-                return NebulaCore.PackageData.FrameItems.Items[ObjectInfo];
+            return ObjectCommon.GetObject(ObjectInfo, ObjectType, this);
         }
 
         public string GetGlobalValueName()

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterExpression.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterExpression.cs
@@ -553,7 +553,8 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
 
         public ObjectInfo? GetObject()
         {
-            if (Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
+            // added here just because without it - any other changes with qualifiers won't do anything (will still get KeyNotFoundException, means that it won't get added)
+            if (Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true || (NebulaCore.Windows && NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0))
                 return null;
             else if (NebulaCore.MFA && Parent?.FrameEvents?.EventObjects.Count > 0)
                 return NebulaCore.PackageData.FrameItems.Items[(int)Parent.FrameEvents.EventObjects[ObjectInfo].ItemHandle];

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterObject.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterObject.cs
@@ -20,13 +20,6 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
             ObjectInfoList = reader.ReadShort();
             ObjectInfo = reader.ReadUShort();
             ObjectType = reader.ReadShort();
-
-            // adds qualifiers if it couldn't find any for Windows, Build >= 296 and Fusion >= 2.5 with 0x8000 bit mask
-            if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
-            {
-                bool exists = Parent?.FrameEvents?.Qualifiers.Where(q => q.ObjectInfo == ObjectInfo && q.Type == ObjectType).Any() == true;
-                if (!exists)
-                    Parent?.FrameEvents?.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType });
             }
         }
 
@@ -48,21 +41,16 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
             Qualifier[] qualifier = Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).ToArray()!;
             if (qualifier.Length > 0)
                 return GetQualifierName(qualifier.First());
-            // if Build >= 296, Windows and Fusion >= 2.5, has 0x8000 bit mask with qualifiers, but didn't find qualifiers, add current qualifier
-            if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
-            {
-                Qualifier? newQualifier = new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType };
-                Parent?.FrameEvents?.Qualifiers.Add(newQualifier);
-                return GetQualifierName(newQualifier);
-            }
             return "Unknown Object";
         }
 
         public ObjectInfo? GetObject()
         {
-            // if Build >= 296, Windows and Fusion >= 2.5, has 0x8000 bit mask with qualifiers, return null
             if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
-                return null;
+            {
+                if (Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).Any() != true)
+                    Parent?.FrameEvents?.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType });
+            }
             if (Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
                 return null;
             else if (NebulaCore.MFA && Parent?.FrameEvents?.EventObjects.Count > 0)

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterObject.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterObject.cs
@@ -38,145 +38,21 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
             ObjectInfo? objectInfo = GetObject();
             if (objectInfo != null)
                 return objectInfo.Name;
-            Qualifier[] qualifier = Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).ToArray()!;
-            if (qualifier.Length > 0)
-                return GetQualifierName(qualifier.First());
-            return "Unknown Object";
+            else
+                return ObjectCommon.TryGetQualifier(this, ObjectInfo, ObjectType);
         }
 
         public ObjectInfo? GetObject()
         {
-            return ObjectCommon.GetObject(ObjectInfo, ObjectType, this);
-        }
-
-        public string GetQualifierName(Qualifier qualifier)
-        {
-            string qualifierName = "Group." + (qualifier.ObjectInfo & 0x7FFF) switch
-            {
-                0 => "Player",
-                1 => "Good",
-                2 => "Neutral",
-                3 => "Bad",
-                4 => "Enemies",
-                5 => "Friends",
-                6 => "Bullets",
-                7 => "Arms",
-                8 => "Bonus",
-                9 => "Collectables",
-                10 => "Traps",
-                11 => "Doors",
-                12 => "Keys",
-                13 => "Texts",
-                14 => "0",
-                15 => "1",
-                16 => "2",
-                17 => "3",
-                18 => "4",
-                19 => "5",
-                20 => "6",
-                21 => "7",
-                22 => "8",
-                23 => "9",
-                24 => "Parents",
-                25 => "Children",
-                26 => "Data",
-                27 => "Timed",
-                28 => "Engine",
-                29 => "Areas",
-                30 => "Reference Points",
-                31 => "Radar Enemies",
-                32 => "Radar Friends",
-                33 => "Radar Neutrals",
-                34 => "Music",
-                35 => "Sound",
-                36 => "Waveform",
-                37 => "Background Scenery",
-                38 => "Foreground Scenery",
-                39 => "Decorations",
-                40 => "Water",
-                41 => "Clouds",
-                42 => "Empty",
-                43 => "Fog",
-                44 => "Flowers",
-                45 => "Animals",
-                46 => "Bosses",
-                47 => "NPC",
-                48 => "Vehicles",
-                49 => "Rockets",
-                50 => "Balls",
-                51 => "Bombs",
-                52 => "Explosions",
-                53 => "Particles",
-                54 => "Clothes",
-                55 => "Glow",
-                56 => "Arrows",
-                57 => "Buttons",
-                58 => "Cursors",
-                59 => "Drawing Tools",
-                60 => "Indicator",
-                61 => "Shapes",
-                62 => "Shields",
-                63 => "Shifting Blocks",
-                64 => "Magnets",
-                65 => "Negative Matter",
-                66 => "Neutral Matter",
-                67 => "Positive Matter",
-                68 => "Breakable",
-                69 => "Dissolving",
-                70 => "Dialogue",
-                71 => "HUD",
-                72 => "Inventory",
-                73 => "Inventory Item",
-                74 => "Interface",
-                75 => "Movable",
-                76 => "Perspective",
-                77 => "Calculation Objects",
-                78 => "Invisible",
-                79 => "Masks",
-                80 => "Obstacles",
-                81 => "Value Holder",
-                82 => "Helpful",
-                83 => "Powerups",
-                84 => "Targets",
-                85 => "Trapdoors",
-                86 => "Dangers",
-                87 => "Forbidden",
-                88 => "Physical objects",
-                89 => "3D Objects",
-                90 => "Generic 1",
-                91 => "Generic 2",
-                92 => "Generic 3",
-                93 => "Generic 4",
-                94 => "Generic 5",
-                95 => "Generic 6",
-                96 => "Generic 7",
-                97 => "Generic 8",
-                98 => "Generic 9",
-                99 => "Generic 10",
-                _ => string.Empty
-            };
-
-            qualifierName += "." + qualifier.Type switch
-            {
-                2 => "Sprite",
-                3 => "Text",
-                4 => "Question",
-                5 => "Score",
-                6 => "Lives",
-                7 => "Counter",
-                _ => string.Empty
-            };
-
-            if (qualifier.Type >= 32 && NebulaCore.PackageData.Extensions.Exts.ContainsKey(qualifier.Type - 32))
-            {
-                Extension ext = NebulaCore.PackageData.Extensions.Exts[qualifier.Type - 32];
-                qualifierName += ext.Name;
-            }
-
-            if (qualifierName.StartsWith("Group.."))
-                return "Unknown Qualifier";
+            // added here just because without it - any other changes with qualifiers won't do anything (will still get KeyNotFoundException, means that it won't get added)
+            if (NebulaCore.Windows && NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
+                return null;
+            if (Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
+                return null;
+            else if (NebulaCore.MFA && Parent?.FrameEvents?.EventObjects.Count > 0)
+                return NebulaCore.PackageData.FrameItems.Items[(int)Parent.FrameEvents.EventObjects[ObjectInfo].ItemHandle];
             else
-                return qualifierName;
+                return NebulaCore.PackageData.FrameItems.Items[ObjectInfo];
         }
     }
 }

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterObject.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterObject.cs
@@ -10,6 +10,8 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
         public ushort ObjectInfo;
         public short ObjectType;
 
+	ACEventBase ace = new ACEventBase(); // for getting public bool Fusion296PC
+
         public ParameterObject()
         {
             ChunkName = "ParameterObject";
@@ -20,6 +22,14 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
             ObjectInfoList = reader.ReadShort();
             ObjectInfo = reader.ReadUShort();
             ObjectType = reader.ReadShort();
+
+            // adds qualifiers if it couldn't find any for Windows, Build >= 296 and Fusion >= 2.5 with 0x8000 bit mask
+            if (ace.Fusion296PC && (ObjectInfo & 0x8000) != 0)
+            {
+                bool exists = Parent?.FrameEvents?.Qualifiers.Where(q => q.ObjectInfo == ObjectInfo && q.Type == ObjectType).Any() == true;
+                if (!exists)
+                    Parent?.FrameEvents?.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType });
+            }
         }
 
         public override void WriteMFA(ByteWriter writer, params object[] extraInfo)
@@ -40,11 +50,21 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
             Qualifier[] qualifier = Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).ToArray()!;
             if (qualifier.Length > 0)
                 return GetQualifierName(qualifier.First());
+            // if Build >= 296, Windows and Fusion >= 2.5, has 0x8000 bit mask with qualifiers, but didn't find qualifiers, add current qualifier
+            if (ace.Fusion296PC && (ObjectInfo & 0x8000) != 0)
+            {
+                Qualifier? newQualifier = new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType };
+                Parent?.FrameEvents?.Qualifiers.Add(newQualifier);
+                return GetQualifierName(newQualifier);
+            }
             return "Unknown Object";
         }
 
         public ObjectInfo? GetObject()
         {
+            // if Build >= 296, Windows and Fusion >= 2.5, has 0x8000 bit mask with qualifiers, return null
+            if (ace.Fusion296PC && (ObjectInfo & 0x8000) != 0)
+                return null;
             if (Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
                 return null;
             else if (NebulaCore.MFA && Parent?.FrameEvents?.EventObjects.Count > 0)

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterObject.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterObject.cs
@@ -46,7 +46,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
 
         public ObjectInfo? GetObject()
         {
-            return ObjectCommon.GetObject(ObjectInfo, ObjectType, null, this);
+            return ObjectCommon.GetObject(ObjectInfo, ObjectType, this);
         }
 
         public string GetQualifierName(Qualifier qualifier)

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterObject.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterObject.cs
@@ -1,5 +1,6 @@
 ﻿using Nebula.Core.Data.Chunks.AppChunks;
 using Nebula.Core.Data.Chunks.ObjectChunks;
+using Nebula.Core.Data.Chunks.ObjectChunks.ObjectCommon;
 using Nebula.Core.Memory;
 
 namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
@@ -45,17 +46,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
 
         public ObjectInfo? GetObject()
         {
-            if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
-            {
-                if (Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).Any() != true)
-                    Parent?.FrameEvents?.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType });
-            }
-            if (Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
-                return null;
-            else if (NebulaCore.MFA && Parent?.FrameEvents?.EventObjects.Count > 0)
-                return NebulaCore.PackageData.FrameItems.Items[(int)Parent.FrameEvents.EventObjects[ObjectInfo].ItemHandle];
-            else
-                return NebulaCore.PackageData.FrameItems.Items[ObjectInfo];
+            return ObjectCommon.GetObject(ObjectInfo, ObjectType, this);
         }
 
         public string GetQualifierName(Qualifier qualifier)

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterObject.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterObject.cs
@@ -45,9 +45,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
         public ObjectInfo? GetObject()
         {
             // added here just because without it - any other changes with qualifiers won't do anything (will still get KeyNotFoundException, means that it won't get added)
-            if (NebulaCore.Windows && NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
-                return null;
-            if (Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
+            if (Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true || (NebulaCore.Windows && NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0))
                 return null;
             else if (NebulaCore.MFA && Parent?.FrameEvents?.EventObjects.Count > 0)
                 return NebulaCore.PackageData.FrameItems.Items[(int)Parent.FrameEvents.EventObjects[ObjectInfo].ItemHandle];

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterObject.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterObject.cs
@@ -10,8 +10,6 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
         public ushort ObjectInfo;
         public short ObjectType;
 
-	ACEventBase ace = new ACEventBase(); // for getting public bool Fusion296PC
-
         public ParameterObject()
         {
             ChunkName = "ParameterObject";
@@ -24,7 +22,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
             ObjectType = reader.ReadShort();
 
             // adds qualifiers if it couldn't find any for Windows, Build >= 296 and Fusion >= 2.5 with 0x8000 bit mask
-            if (ace.Fusion296PC && (ObjectInfo & 0x8000) != 0)
+            if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
             {
                 bool exists = Parent?.FrameEvents?.Qualifiers.Where(q => q.ObjectInfo == ObjectInfo && q.Type == ObjectType).Any() == true;
                 if (!exists)
@@ -51,7 +49,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
             if (qualifier.Length > 0)
                 return GetQualifierName(qualifier.First());
             // if Build >= 296, Windows and Fusion >= 2.5, has 0x8000 bit mask with qualifiers, but didn't find qualifiers, add current qualifier
-            if (ace.Fusion296PC && (ObjectInfo & 0x8000) != 0)
+            if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
             {
                 Qualifier? newQualifier = new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType };
                 Parent?.FrameEvents?.Qualifiers.Add(newQualifier);
@@ -63,7 +61,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
         public ObjectInfo? GetObject()
         {
             // if Build >= 296, Windows and Fusion >= 2.5, has 0x8000 bit mask with qualifiers, return null
-            if (ace.Fusion296PC && (ObjectInfo & 0x8000) != 0)
+            if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
                 return null;
             if (Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
                 return null;

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterObject.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterObject.cs
@@ -46,7 +46,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
 
         public ObjectInfo? GetObject()
         {
-            return ObjectCommon.GetObject(ObjectInfo, ObjectType, this);
+            return ObjectCommon.GetObject(ObjectInfo, ObjectType, null, this);
         }
 
         public string GetQualifierName(Qualifier qualifier)

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterObject.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterObject.cs
@@ -20,7 +20,6 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
             ObjectInfoList = reader.ReadShort();
             ObjectInfo = reader.ReadUShort();
             ObjectType = reader.ReadShort();
-            }
         }
 
         public override void WriteMFA(ByteWriter writer, params object[] extraInfo)

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterPosition.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterPosition.cs
@@ -97,7 +97,8 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
 
         public ObjectInfo? GetObject()
         {
-            if (Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfoParent).Any() == true)
+            // added here just because without it - any other changes with qualifiers won't do anything (will still get KeyNotFoundException, means that it won't get added)
+            if (Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfoParent).Any() == true || (NebulaCore.Windows && NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 &&(ObjectInfoParent & 0x8000) != 0))
                 return null;
             else if (NebulaCore.MFA && Parent?.FrameEvents?.EventObjects.Count > 0)
                 return NebulaCore.PackageData.FrameItems.Items[(int)Parent.FrameEvents.EventObjects[ObjectInfoParent].ItemHandle];

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterPosition.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterPosition.cs
@@ -1,6 +1,7 @@
 ﻿using ILGPU.IR.Types;
 using Nebula.Core.Data.Chunks.AppChunks;
 using Nebula.Core.Data.Chunks.ObjectChunks;
+using Nebula.Core.Data.Chunks.ObjectChunks.ObjectCommon;
 using Nebula.Core.Memory;
 
 namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
@@ -96,12 +97,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
 
         public ObjectInfo? GetObject()
         {
-            if (Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfoParent).Any() == true)
-                return null;
-            else if (NebulaCore.MFA && Parent?.FrameEvents?.EventObjects.Count > 0)
-                return NebulaCore.PackageData.FrameItems.Items[(int)Parent.FrameEvents.EventObjects[ObjectInfoParent].ItemHandle];
-            else
-                return NebulaCore.PackageData.FrameItems.Items[ObjectInfoParent];
+            return ObjectCommon.GetObject(ObjectInfoParent, TypeParent, this);
         }
 
         public string GetObjectName()

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterPosition.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterPosition.cs
@@ -97,7 +97,12 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
 
         public ObjectInfo? GetObject()
         {
-            return ObjectCommon.GetObject(ObjectInfoParent, TypeParent, this);
+            if (Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfoParent).Any() == true)
+                return null;
+            else if (NebulaCore.MFA && Parent?.FrameEvents?.EventObjects.Count > 0)
+                return NebulaCore.PackageData.FrameItems.Items[(int)Parent.FrameEvents.EventObjects[ObjectInfoParent].ItemHandle];
+            else
+                return NebulaCore.PackageData.FrameItems.Items[ObjectInfoParent];
         }
 
         public string GetObjectName()
@@ -105,140 +110,8 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
             ObjectInfo? objectInfo = GetObject();
             if (objectInfo != null)
                 return objectInfo.Name;
-            Qualifier[] qualifier = Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfoParent && x.Type == TypeParent).ToArray()!;
-            if (qualifier.Length > 0)
-                return GetQualifierName(qualifier.First());
-            return "Unknown Object";
-        }
-
-        public string GetQualifierName(Qualifier qualifier)
-        {
-            string qualifierName = "Group." + (qualifier.ObjectInfo & 0x7FFF) switch
-            {
-                0 => "Player",
-                1 => "Good",
-                2 => "Neutral",
-                3 => "Bad",
-                4 => "Enemies",
-                5 => "Friends",
-                6 => "Bullets",
-                7 => "Arms",
-                8 => "Bonus",
-                9 => "Collectables",
-                10 => "Traps",
-                11 => "Doors",
-                12 => "Keys",
-                13 => "Texts",
-                14 => "0",
-                15 => "1",
-                16 => "2",
-                17 => "3",
-                18 => "4",
-                19 => "5",
-                20 => "6",
-                21 => "7",
-                22 => "8",
-                23 => "9",
-                24 => "Parents",
-                25 => "Children",
-                26 => "Data",
-                27 => "Timed",
-                28 => "Engine",
-                29 => "Areas",
-                30 => "Reference Points",
-                31 => "Radar Enemies",
-                32 => "Radar Friends",
-                33 => "Radar Neutrals",
-                34 => "Music",
-                35 => "Sound",
-                36 => "Waveform",
-                37 => "Background Scenery",
-                38 => "Foreground Scenery",
-                39 => "Decorations",
-                40 => "Water",
-                41 => "Clouds",
-                42 => "Empty",
-                43 => "Fog",
-                44 => "Flowers",
-                45 => "Animals",
-                46 => "Bosses",
-                47 => "NPC",
-                48 => "Vehicles",
-                49 => "Rockets",
-                50 => "Balls",
-                51 => "Bombs",
-                52 => "Explosions",
-                53 => "Particles",
-                54 => "Clothes",
-                55 => "Glow",
-                56 => "Arrows",
-                57 => "Buttons",
-                58 => "Cursors",
-                59 => "Drawing Tools",
-                60 => "Indicator",
-                61 => "Shapes",
-                62 => "Shields",
-                63 => "Shifting Blocks",
-                64 => "Magnets",
-                65 => "Negative Matter",
-                66 => "Neutral Matter",
-                67 => "Positive Matter",
-                68 => "Breakable",
-                69 => "Dissolving",
-                70 => "Dialogue",
-                71 => "HUD",
-                72 => "Inventory",
-                73 => "Inventory Item",
-                74 => "Interface",
-                75 => "Movable",
-                76 => "Perspective",
-                77 => "Calculation Objects",
-                78 => "Invisible",
-                79 => "Masks",
-                80 => "Obstacles",
-                81 => "Value Holder",
-                82 => "Helpful",
-                83 => "Powerups",
-                84 => "Targets",
-                85 => "Trapdoors",
-                86 => "Dangers",
-                87 => "Forbidden",
-                88 => "Physical objects",
-                89 => "3D Objects",
-                90 => "Generic 1",
-                91 => "Generic 2",
-                92 => "Generic 3",
-                93 => "Generic 4",
-                94 => "Generic 5",
-                95 => "Generic 6",
-                96 => "Generic 7",
-                97 => "Generic 8",
-                98 => "Generic 9",
-                99 => "Generic 10",
-                _ => string.Empty
-            };
-
-            qualifierName += "." + qualifier.Type switch
-            {
-                2 => "Sprite",
-                3 => "Text",
-                4 => "Question",
-                5 => "Score",
-                6 => "Lives",
-                7 => "Counter",
-                _ => string.Empty
-            };
-
-            if (qualifier.Type >= 32 && NebulaCore.PackageData.Extensions.Exts.ContainsKey(qualifier.Type - 32))
-            {
-                Extension ext = NebulaCore.PackageData.Extensions.Exts[qualifier.Type - 32];
-                qualifierName += ext.Name;
-            }
-
-            if (qualifierName.StartsWith("Group.."))
-                return "Unknown Qualifier";
             else
-                return qualifierName;
+                return ObjectCommon.TryGetQualifier(this, ObjectInfoParent, ObjectInfoList);
         }
     }
 }

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterPosition.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterPosition.cs
@@ -97,7 +97,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
 
         public ObjectInfo? GetObject()
         {
-            return ObjectCommon.GetObject(ObjectInfoParent, TypeParent, this);
+            return ObjectCommon.GetObject(ObjectInfoParent, TypeParent, null, this);
         }
 
         public string GetObjectName()

--- a/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterPosition.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/Events/Parameters/ParameterPosition.cs
@@ -97,7 +97,7 @@ namespace Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters
 
         public ObjectInfo? GetObject()
         {
-            return ObjectCommon.GetObject(ObjectInfoParent, TypeParent, null, this);
+            return ObjectCommon.GetObject(ObjectInfoParent, TypeParent, this);
         }
 
         public string GetObjectName()

--- a/Nebula.Core/Data/Chunks/FrameChunks/FrameEvents.cs
+++ b/Nebula.Core/Data/Chunks/FrameChunks/FrameEvents.cs
@@ -84,10 +84,6 @@ namespace Nebula.Core.Data.Chunks.FrameChunks
 						qualifier.ReadCCN(reader);
                         Qualifiers.Add(qualifier);
                     }
-
-                    // Just incase, 296 shouldnt be writing qualifiers anyway
-                    if (NebulaCore.Build >= 296 && NebulaCore.Windows && NebulaCore.Fusion >= 2.5)
-                        Qualifiers.Clear();
                 }
                 else if (identifier == "ERes")
                     EventCount = reader.ReadInt();

--- a/Nebula.Core/Data/Chunks/ObjectChunks/ObjectCommon/ObjectCommon.cs
+++ b/Nebula.Core/Data/Chunks/ObjectChunks/ObjectCommon/ObjectCommon.cs
@@ -239,20 +239,6 @@ namespace Nebula.Core.Data.Chunks.ObjectChunks.ObjectCommon
 
         }
 
-        // method for getting qualifiers in ACE
-        public static string TryGetQualifierACE(ACEventBase ace, ushort ObjectInfo, short ObjectType)
-        {
-            if (ace.Parent?.Parent.Qualifiers.Where(q => q.ObjectInfo == ObjectInfo && q.Type == ObjectType).Any() != true)
-            {
-                if ((ObjectInfo & 0x8000) != 0)
-                    ace.Parent?.Parent.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType}); 
-            }
-            Qualifier[] qualifiers = ace.Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).ToArray()!;
-            if (qualifiers.Length > 0)
-                return GetQualifierName(qualifiers.First());
-            return "Unknown Object";
-        }
-
         // method for getting qualifiers in different places
         public static string TryGetQualifier(ParameterChunk paramChunk, ushort ObjectInfo, short ObjectType)
         {

--- a/Nebula.Core/Data/Chunks/ObjectChunks/ObjectCommon/ObjectCommon.cs
+++ b/Nebula.Core/Data/Chunks/ObjectChunks/ObjectCommon/ObjectCommon.cs
@@ -1,4 +1,6 @@
 ﻿using Nebula.Core.Data.Chunks.ChunkTypes;
+using Nebula.Core.Data.Chunks.FrameChunks.Events;
+using Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters;
 using Nebula.Core.Memory;
 using System.Diagnostics;
 using System.Drawing;
@@ -234,6 +236,38 @@ namespace Nebula.Core.Data.Chunks.ObjectChunks.ObjectCommon
         public override void WriteMFA(ByteWriter writer, params object[] extraInfo)
         {
 
+        }
+
+        // method for getting object/qualifier in ACEventBase
+        public static ObjectInfo? GetObjectACEventBase(ushort ObjectInfo, short ObjectType, ACEventBase ace)
+        {
+            if (NebulaCore.Windows && NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
+            {
+                if (ace.Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).Any() != true)
+                    ace.Parent?.Parent.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType });
+            }
+            if (ace.Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
+                return null;
+            else if (NebulaCore.MFA && ace.Parent?.Parent.EventObjects.Count > 0)
+                return NebulaCore.PackageData.FrameItems.Items[(int)ace.Parent.Parent.EventObjects[ObjectInfo].ItemHandle];
+            else
+                return NebulaCore.PackageData.FrameItems.Items[ObjectInfo];
+        }
+
+        //method for getting object/qualifier in different places
+        public static ObjectInfo? GetObject(ushort ObjectInfo, short ObjectType, ParameterChunk paramChunk)
+        {
+            if (NebulaCore.Windows && NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
+            {
+                if (paramChunk.Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).Any() != true)
+                    paramChunk.Parent?.FrameEvents?.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType });
+            }
+            if (paramChunk.Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
+                return null;
+            else if (NebulaCore.MFA && paramChunk.Parent?.FrameEvents?.EventObjects.Count > 0)
+                return NebulaCore.PackageData.FrameItems.Items[(int)paramChunk.Parent.FrameEvents.EventObjects[ObjectInfo].ItemHandle];
+            else
+                return NebulaCore.PackageData.FrameItems.Items[ObjectInfo];
         }
 
         public void GetOffset(ByteReader reader, int index, bool check = false)

--- a/Nebula.Core/Data/Chunks/ObjectChunks/ObjectCommon/ObjectCommon.cs
+++ b/Nebula.Core/Data/Chunks/ObjectChunks/ObjectCommon/ObjectCommon.cs
@@ -238,38 +238,36 @@ namespace Nebula.Core.Data.Chunks.ObjectChunks.ObjectCommon
 
         }
 
-        // method for getting objects/qualifiers to prevent copy paste
-        public static ObjectInfo? GetObject(ushort ObjectInfo, short ObjectType, ACEventBase ace, ParameterChunk paramChunk)
+        // method for getting object/qualifier in ACEventBase
+        public static ObjectInfo? GetObjectACEventBase(ushort ObjectInfo, short ObjectType, ACEventBase ace)
         {
-            if (ace != null)
+            if (NebulaCore.Windows && NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
             {
-                if (NebulaCore.Windows && NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
-                {
-                    if (ace.Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).Any() != true)
-                        ace.Parent?.Parent.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType });
-                }
-                if (ace.Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
-                    return null;
-                else if (NebulaCore.MFA && ace.Parent?.Parent.EventObjects.Count > 0)
-                    return NebulaCore.PackageData.FrameItems.Items[(int)ace.Parent.Parent.EventObjects[ObjectInfo].ItemHandle];
-                else
-                    return NebulaCore.PackageData.FrameItems.Items[ObjectInfo];
+                if (ace.Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).Any() != true)
+                    ace.Parent?.Parent.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType });
             }
-            else if (paramChunk != null)
+            if (ace.Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
+                return null;
+            else if (NebulaCore.MFA && ace.Parent?.Parent.EventObjects.Count > 0)
+                return NebulaCore.PackageData.FrameItems.Items[(int)ace.Parent.Parent.EventObjects[ObjectInfo].ItemHandle];
+            else
+                return NebulaCore.PackageData.FrameItems.Items[ObjectInfo];
+        }
+
+        //method for getting object/qualifier in different places
+        public static ObjectInfo? GetObject(ushort ObjectInfo, short ObjectType, ParameterChunk paramChunk)
+        {
+            if (NebulaCore.Windows && NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
             {
-                if (NebulaCore.Windows && NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
-                {
-                    if (paramChunk.Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).Any() != true)
-                        paramChunk.Parent?.FrameEvents?.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType });
-                }
-                if (paramChunk.Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
-                    return null;
-                else if (NebulaCore.MFA && paramChunk.Parent?.FrameEvents?.EventObjects.Count > 0)
-                    return NebulaCore.PackageData.FrameItems.Items[(int)paramChunk.Parent.FrameEvents.EventObjects[ObjectInfo].ItemHandle];
-                else
-                    return NebulaCore.PackageData.FrameItems.Items[ObjectInfo];
+                if (paramChunk.Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).Any() != true)
+                    paramChunk.Parent?.FrameEvents?.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType });
             }
-            return null; 
+            if (paramChunk.Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
+                return null;
+            else if (NebulaCore.MFA && paramChunk.Parent?.FrameEvents?.EventObjects.Count > 0)
+                return NebulaCore.PackageData.FrameItems.Items[(int)paramChunk.Parent.FrameEvents.EventObjects[ObjectInfo].ItemHandle];
+            else
+                return NebulaCore.PackageData.FrameItems.Items[ObjectInfo];
         }
 
         public void GetOffset(ByteReader reader, int index, bool check = false)

--- a/Nebula.Core/Data/Chunks/ObjectChunks/ObjectCommon/ObjectCommon.cs
+++ b/Nebula.Core/Data/Chunks/ObjectChunks/ObjectCommon/ObjectCommon.cs
@@ -238,36 +238,38 @@ namespace Nebula.Core.Data.Chunks.ObjectChunks.ObjectCommon
 
         }
 
-        // method for getting object/qualifier in ACEventBase
-        public static ObjectInfo? GetObjectACEventBase(ushort ObjectInfo, short ObjectType, ACEventBase ace)
+        // method for getting objects/qualifiers to prevent copy paste
+        public static ObjectInfo? GetObject(ushort ObjectInfo, short ObjectType, ACEventBase ace, ParameterChunk paramChunk)
         {
-            if (NebulaCore.Windows && NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
+            if (ace != null)
             {
-                if (ace.Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).Any() != true)
-                    ace.Parent?.Parent.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType });
+                if (NebulaCore.Windows && NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
+                {
+                    if (ace.Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).Any() != true)
+                        ace.Parent?.Parent.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType });
+                }
+                if (ace.Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
+                    return null;
+                else if (NebulaCore.MFA && ace.Parent?.Parent.EventObjects.Count > 0)
+                    return NebulaCore.PackageData.FrameItems.Items[(int)ace.Parent.Parent.EventObjects[ObjectInfo].ItemHandle];
+                else
+                    return NebulaCore.PackageData.FrameItems.Items[ObjectInfo];
             }
-            if (ace.Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
-                return null;
-            else if (NebulaCore.MFA && ace.Parent?.Parent.EventObjects.Count > 0)
-                return NebulaCore.PackageData.FrameItems.Items[(int)ace.Parent.Parent.EventObjects[ObjectInfo].ItemHandle];
-            else
-                return NebulaCore.PackageData.FrameItems.Items[ObjectInfo];
-        }
-
-        //method for getting object/qualifier in different places
-        public static ObjectInfo? GetObject(ushort ObjectInfo, short ObjectType, ParameterChunk paramChunk)
-        {
-            if (NebulaCore.Windows && NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
+            else if (paramChunk != null)
             {
-                if (paramChunk.Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).Any() != true)
-                    paramChunk.Parent?.FrameEvents?.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType });
+                if (NebulaCore.Windows && NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
+                {
+                    if (paramChunk.Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).Any() != true)
+                        paramChunk.Parent?.FrameEvents?.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType });
+                }
+                if (paramChunk.Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
+                    return null;
+                else if (NebulaCore.MFA && paramChunk.Parent?.FrameEvents?.EventObjects.Count > 0)
+                    return NebulaCore.PackageData.FrameItems.Items[(int)paramChunk.Parent.FrameEvents.EventObjects[ObjectInfo].ItemHandle];
+                else
+                    return NebulaCore.PackageData.FrameItems.Items[ObjectInfo];
             }
-            if (paramChunk.Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
-                return null;
-            else if (NebulaCore.MFA && paramChunk.Parent?.FrameEvents?.EventObjects.Count > 0)
-                return NebulaCore.PackageData.FrameItems.Items[(int)paramChunk.Parent.FrameEvents.EventObjects[ObjectInfo].ItemHandle];
-            else
-                return NebulaCore.PackageData.FrameItems.Items[ObjectInfo];
+            return null; 
         }
 
         public void GetOffset(ByteReader reader, int index, bool check = false)

--- a/Nebula.Core/Data/Chunks/ObjectChunks/ObjectCommon/ObjectCommon.cs
+++ b/Nebula.Core/Data/Chunks/ObjectChunks/ObjectCommon/ObjectCommon.cs
@@ -4,6 +4,7 @@ using Nebula.Core.Data.Chunks.FrameChunks.Events.Parameters;
 using Nebula.Core.Memory;
 using System.Diagnostics;
 using System.Drawing;
+using Nebula.Core.Data.Chunks.AppChunks;
 
 namespace Nebula.Core.Data.Chunks.ObjectChunks.ObjectCommon
 {
@@ -238,36 +239,162 @@ namespace Nebula.Core.Data.Chunks.ObjectChunks.ObjectCommon
 
         }
 
-        // method for getting object/qualifier in ACEventBase
-        public static ObjectInfo? GetObjectACEventBase(ushort ObjectInfo, short ObjectType, ACEventBase ace)
+        // method for getting qualifiers in ACE
+        public static string TryGetQualifierACE(ACEventBase ace, ushort ObjectInfo, short ObjectType)
         {
-            if (NebulaCore.Windows && NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
+            if (ace.Parent?.Parent.Qualifiers.Where(q => q.ObjectInfo == ObjectInfo && q.Type == ObjectType).Any() != true)
             {
-                if (ace.Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).Any() != true)
-                    ace.Parent?.Parent.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType });
+                if ((ObjectInfo & 0x8000) != 0)
+                    ace.Parent?.Parent.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType}); 
             }
-            if (ace.Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
-                return null;
-            else if (NebulaCore.MFA && ace.Parent?.Parent.EventObjects.Count > 0)
-                return NebulaCore.PackageData.FrameItems.Items[(int)ace.Parent.Parent.EventObjects[ObjectInfo].ItemHandle];
-            else
-                return NebulaCore.PackageData.FrameItems.Items[ObjectInfo];
+            Qualifier[] qualifiers = ace.Parent?.Parent.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).ToArray()!;
+            if (qualifiers.Length > 0)
+                return GetQualifierName(qualifiers.First());
+            return "Unknown Object";
         }
 
-        //method for getting object/qualifier in different places
-        public static ObjectInfo? GetObject(ushort ObjectInfo, short ObjectType, ParameterChunk paramChunk)
+        // method for getting qualifiers in different places
+        public static string TryGetQualifier(ParameterChunk paramChunk, ushort ObjectInfo, short ObjectType)
         {
-            if (NebulaCore.Windows && NebulaCore.Build >= 296 && NebulaCore.Fusion >= 2.5 && (ObjectInfo & 0x8000) != 0)
+            if (paramChunk.Parent?.FrameEvents?.Qualifiers.Where(q => q.ObjectInfo == ObjectInfo && q.Type == ObjectType).Any() != true)
             {
-                if (paramChunk.Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).Any() != true)
+                if ((ObjectInfo & 0x8000) != 0)
                     paramChunk.Parent?.FrameEvents?.Qualifiers.Add(new Qualifier() { ObjectInfo = ObjectInfo, Type = ObjectType });
             }
-            if (paramChunk.Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo).Any() == true)
-                return null;
-            else if (NebulaCore.MFA && paramChunk.Parent?.FrameEvents?.EventObjects.Count > 0)
-                return NebulaCore.PackageData.FrameItems.Items[(int)paramChunk.Parent.FrameEvents.EventObjects[ObjectInfo].ItemHandle];
+            Qualifier[] qualifiers = paramChunk.Parent?.FrameEvents?.Qualifiers.Where(x => x.ObjectInfo == ObjectInfo && x.Type == ObjectType).ToArray()!;
+            if (qualifiers.Length > 0)
+                return GetQualifierName(qualifiers.First());
+            return "Unknown Object";
+        }
+
+        public static string GetQualifierName(Qualifier qualifier)
+        {
+            string qualifierName = "Group." + (qualifier.ObjectInfo & 0x7FFF) switch
+            {
+                0 => "Player",
+                1 => "Good",
+                2 => "Neutral",
+                3 => "Bad",
+                4 => "Enemies",
+                5 => "Friends",
+                6 => "Bullets",
+                7 => "Arms",
+                8 => "Bonus",
+                9 => "Collectables",
+                10 => "Traps",
+                11 => "Doors",
+                12 => "Keys",
+                13 => "Texts",
+                14 => "0",
+                15 => "1",
+                16 => "2",
+                17 => "3",
+                18 => "4",
+                19 => "5",
+                20 => "6",
+                21 => "7",
+                22 => "8",
+                23 => "9",
+                24 => "Parents",
+                25 => "Children",
+                26 => "Data",
+                27 => "Timed",
+                28 => "Engine",
+                29 => "Areas",
+                30 => "Reference Points",
+                31 => "Radar Enemies",
+                32 => "Radar Friends",
+                33 => "Radar Neutrals",
+                34 => "Music",
+                35 => "Sound",
+                36 => "Waveform",
+                37 => "Background Scenery",
+                38 => "Foreground Scenery",
+                39 => "Decorations",
+                40 => "Water",
+                41 => "Clouds",
+                42 => "Empty",
+                43 => "Fog",
+                44 => "Flowers",
+                45 => "Animals",
+                46 => "Bosses",
+                47 => "NPC",
+                48 => "Vehicles",
+                49 => "Rockets",
+                50 => "Balls",
+                51 => "Bombs",
+                52 => "Explosions",
+                53 => "Particles",
+                54 => "Clothes",
+                55 => "Glow",
+                56 => "Arrows",
+                57 => "Buttons",
+                58 => "Cursors",
+                59 => "Drawing Tools",
+                60 => "Indicator",
+                61 => "Shapes",
+                62 => "Shields",
+                63 => "Shifting Blocks",
+                64 => "Magnets",
+                65 => "Negative Matter",
+                66 => "Neutral Matter",
+                67 => "Positive Matter",
+                68 => "Breakable",
+                69 => "Dissolving",
+                70 => "Dialogue",
+                71 => "HUD",
+                72 => "Inventory",
+                73 => "Inventory Item",
+                74 => "Interface",
+                75 => "Movable",
+                76 => "Perspective",
+                77 => "Calculation Objects",
+                78 => "Invisible",
+                79 => "Masks",
+                80 => "Obstacles",
+                81 => "Value Holder",
+                82 => "Helpful",
+                83 => "Powerups",
+                84 => "Targets",
+                85 => "Trapdoors",
+                86 => "Dangers",
+                87 => "Forbidden",
+                88 => "Physical objects",
+                89 => "3D Objects",
+                90 => "Generic 1",
+                91 => "Generic 2",
+                92 => "Generic 3",
+                93 => "Generic 4",
+                94 => "Generic 5",
+                95 => "Generic 6",
+                96 => "Generic 7",
+                97 => "Generic 8",
+                98 => "Generic 9",
+                99 => "Generic 10",
+                _ => string.Empty
+            };
+
+            qualifierName += "." + qualifier.Type switch
+            {
+                2 => "Sprite",
+                3 => "Text",
+                4 => "Question",
+                5 => "Score",
+                6 => "Lives",
+                7 => "Counter",
+                _ => string.Empty
+            };
+
+            if (qualifier.Type >= 32 && NebulaCore.PackageData.Extensions.Exts.ContainsKey(qualifier.Type - 32))
+            {
+                Extension ext = NebulaCore.PackageData.Extensions.Exts[qualifier.Type - 32];
+                qualifierName += ext.Name;
+            }
+
+            if (qualifierName.StartsWith("Group.."))
+                return "Unknown Qualifier";
             else
-                return NebulaCore.PackageData.FrameItems.Items[ObjectInfo];
+                return qualifierName;
         }
 
         public void GetOffset(ByteReader reader, int index, bool check = false)

--- a/Nebula.Core/FileReaders/APKFileReader.cs
+++ b/Nebula.Core/FileReaders/APKFileReader.cs
@@ -11,9 +11,19 @@ namespace Nebula.Core.FileReaders
 {
     public class APKFileReader : IFileReader
     {
-        public string Name => "APK/XAPK";
+        public string Name => "Android";
         public Dictionary<int, Bitmap> Icons { get { return _icons; } set { _icons = value; } }
         private Dictionary<int, Bitmap> _icons = new Dictionary<int, Bitmap>();
+
+        private static readonly List<string> VideoExtensions = new List<string>
+        {
+            ".mp4",
+            ".mkv",
+            ".m4a",
+            ".mov",
+            ".webm",
+            ".avi"
+        };
 
         public string FilePath { get { return _filePath; } set { _filePath = value; } }
         public string _filePath = string.Empty;
@@ -47,7 +57,7 @@ namespace Nebula.Core.FileReaders
                         entry.Open().CopyTo(ms);
                         SoundBank.ExternalFiles[Path.GetFileNameWithoutExtension(entry.Name)] = ms.ToArray(); // saving it to dictionary
                     }
-                    else if (Path.GetExtension(entry.Name) == ".mp4") // for unpacking video files saved by Video Android extension
+                    else if (VideoExtensions.Contains(Path.GetExtension(entry.Name))) // for unpacking video files saved by Video Android extension
                     {
                         using var stream = entry.Open();
                         using var memoryStream = new MemoryStream();

--- a/Nebula.Core/FileReaders/APKFileReader.cs
+++ b/Nebula.Core/FileReaders/APKFileReader.cs
@@ -11,7 +11,7 @@ namespace Nebula.Core.FileReaders
 {
     public class APKFileReader : IFileReader
     {
-        public string Name => "APK";
+        public string Name => "APK/XAPK";
         public Dictionary<int, Bitmap> Icons { get { return _icons; } set { _icons = value; } }
         private Dictionary<int, Bitmap> _icons = new Dictionary<int, Bitmap>();
 
@@ -46,6 +46,21 @@ namespace Nebula.Core.FileReaders
                         using MemoryStream ms = new();
                         entry.Open().CopyTo(ms);
                         SoundBank.ExternalFiles[Path.GetFileNameWithoutExtension(entry.Name)] = ms.ToArray(); // saving it to dictionary
+                    }
+                    else if (Path.GetExtension(entry.Name) == ".mp4") // for unpacking video files saved by Video Android extension
+                    {
+                        using var stream = entry.Open();
+                        using var memoryStream = new MemoryStream();
+                        stream.CopyTo(memoryStream);
+                        byte[] fileData = memoryStream.ToArray();
+
+                        // add videos to binary files list for dumping
+                        BinaryFile binFile = new BinaryFile
+                        {
+                            FileName = entry.Name,
+                            FileData = fileData
+                        };
+                        NebulaCore.PackageData.BinaryFiles.Items.Add(binFile);
                     }
                 }
                 if (Directory.GetParent(entry.FullName)?.Name == "fonts" && Path.GetExtension(entry.Name) == ".ttf")

--- a/Nebula.Core/FileReaders/APKFileReader.cs
+++ b/Nebula.Core/FileReaders/APKFileReader.cs
@@ -1,4 +1,5 @@
 ﻿using Nebula.Core.Data;
+using Nebula.Core.Data.Chunks.AppChunks;
 using Nebula.Core.Data.Chunks.BankChunks.Sounds;
 using Nebula.Core.Data.Chunks.BankChunks.TrueTypeFonts;
 using Nebula.Core.Data.PackageReaders;
@@ -17,14 +18,16 @@ namespace Nebula.Core.FileReaders
 
         private static readonly List<string> VideoExtensions = new List<string>
         {
+            // list of supported video extensions by Video Android extension, not adding .ogg tho because there's also .ogg file as a sound
             ".mp4",
-            ".mkv",
-            ".m4a",
-            ".mov",
             ".webm",
-            ".avi"
+            ".mpeg",
+            ".ogv",
+            ".ts",
+            ".dat",
+            ".m4v",
         };
-
+            
         public string FilePath { get { return _filePath; } set { _filePath = value; } }
         public string _filePath = string.Empty;
 
@@ -111,7 +114,6 @@ namespace Nebula.Core.FileReaders
             };
             NebulaCore.PackageData.TrueTypeFontBank.Fonts.Add(ttf); // then add font to the bank
         }
-
 
         private void loadIcons(Bitmap bmp)
         {

--- a/Nebula.Core/FileReaders/IPAFileReader.cs
+++ b/Nebula.Core/FileReaders/IPAFileReader.cs
@@ -22,7 +22,9 @@ namespace Nebula.Core.FileReaders
         public void LoadGame(ByteReader fileReader, string filePath)
         {
             ByteReader? ccnReader = null;
-            ZipArchive archive = ZipFile.OpenRead(_filePath = filePath);
+
+            FileStream fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            ZipArchive archive = new ZipArchive(fs, ZipArchiveMode.Read);
             string appName = string.Empty;
             foreach (ZipArchiveEntry entry in archive.Entries)
             {

--- a/Nebula.Core/Memory/ByteReader.cs
+++ b/Nebula.Core/Memory/ByteReader.cs
@@ -91,7 +91,7 @@ namespace Nebula.Core.Memory
 
         public override double ReadDouble()
         {
-            if (!NebulaCore.Windows)
+            if (NebulaCore.Android) // changed for android only because this could break values for iOS
                 return ReadLong() / 4294967296.0;
             return base.ReadDouble();
         }

--- a/Nebula.Tools/GameDumper/AssetDumpers/ShaderDumper.cs
+++ b/Nebula.Tools/GameDumper/AssetDumpers/ShaderDumper.cs
@@ -28,7 +28,9 @@ namespace GameDumper.AssetDumpers
             {
                 string filePath = "";
                 if (NebulaCore.Android)
-		    filePath = path + Path.GetFileNameWithoutExtension(shdrs[i].Name) + ".fxao"; // Android has only OpenGL shader, there's no DX9 and DX11 (so you need to find them somewhere else)
+                    filePath = path + Path.GetFileNameWithoutExtension(shdrs[i].Name) + ".fxao"; // Android has only OpenGL shader and they're in DX9 bank (you need to find original .fx files somewhere)
+                else if (NebulaCore.iOS)
+                    filePath = path + Path.GetFileNameWithoutExtension(shdrs[i].Name) + ".fxmo"; // same thing with iOS as Android
                 else
                     filePath = path + Path.GetFileNameWithoutExtension(shdrs[i].Name) + (shdrs[i].Compiled ? ".fxc" : ".fx");
                 File.WriteAllBytes(filePath, shdrs[i].FXData);


### PR DESCRIPTION
- Fixed qualifiers for Windows platform and build 296 (removed from Action.cs and Condition.cs because changes in ACEventBase.cs and ParameterObject.cs fixes it)
- For Android - added .xapk reading, added unpacking videos if it was saved by Video Android extension (it won't add to Binary Files in the project)