### PR TITLE
ObjectAnimation offsets should be unsigned

### DIFF
--- a/Nebula.Core/Data/Chunks/ObjectChunks/ObjectCommon/ObjectAnimations.cs
+++ b/Nebula.Core/Data/Chunks/ObjectChunks/ObjectCommon/ObjectAnimations.cs
@@ -18,9 +18,9 @@ namespace Nebula.Core.Data.Chunks.ObjectChunks.ObjectCommon
             reader.ReadShort();
             short Count = reader.ReadShort();
 
-            short[] Offsets = new short[Count];
+            ushort[] Offsets = new ushort[Count];
             for (int i = 0; i < Count; i++)
-                Offsets[i] = reader.ReadShort();
+                Offsets[i] = reader.ReadUShort();
 
             Animations = new Dictionary<int, ObjectAnimation>();
             for (int i = 0; i < Count; i++)


### PR DESCRIPTION
If the animation data gets big enough to the point an offset is higher than 32,767 it will crash Nebula for trying to seek into negatives.